### PR TITLE
add Redis.Wait for redis cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ flowchart LR
 2. `queueDigest = SHA-256(length-prefix(prefix, channel, topic))`. Each length uses an 8-byte big-endian encoding. This prevents ambiguous route concatenation and keeps raw business values out of Redis Cluster hash tags.
 3. When `normalQueuePartitions = 0` or `sequenceQueuePartitions = 0`, the value falls back to `minConsumers` for compatibility. Any final non-positive value is normalized to `1`.
 4. The first publisher or consumer writes `schema/partitions/capacity` metadata. Later instances fail when their configuration differs, so **the partition count and `redis.maxLen` cannot be changed in place after queue creation**.
-5. `consumerPoolSize` is the number of message-processing workers per instance, not the partition count. Each instance scans every fixed partition and sends messages to one shared worker pool.
+5. `consumerPoolSize` is the number of message-processing workers per consumer, not the partition count. `consumerReaderPoolSize` is the number of partition readers per consumer; readers divide the fixed partitions by stride and send messages to one shared worker pool. The effective reader count never exceeds the partition count.
 
 ### 1. Normal Queue
 
@@ -366,7 +366,8 @@ _, err := consumer.BQ().WithContext(ctx).
 | Route normal/delay messages consistently | Use `SetId` with a stable, unique business message ID | The same ID always produces the same hash result |
 | Preserve strict order for one order | Use the order number as `orderKey` | All messages for the order enter the same FIFO List |
 | Process different orders concurrently | Use different `orderKey` values and configure enough workers | Ordering constraints apply only to one `orderKey` |
-| Increase processing capacity | Prefer adding instances or increasing `consumerPoolSize` | Fixed partition counts cannot be changed online |
+| Increase handler capacity | Prefer adding instances or increasing `consumerPoolSize` | Fixed partition counts cannot be changed online |
+| Reduce partition scan latency | Increase `consumerReaderPoolSize` carefully | More readers increase concurrent Redis requests and connection pressure |
 
 > Changing the partition count changes modulo results and maps the same partition key to a different partition; metadata validation also rejects the new configuration. To change the partition count in production, create a new logical queue with a new `channel/topic`, then migrate or drain the old queue.
 
@@ -494,6 +495,7 @@ _, err := consumer.BQ().
   },
   "broker": "redis",
   "consumerPoolSize": 10,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "60s",
   "deadLetterTicker": "5s",
   "jobMaxRetries": 3,
@@ -564,6 +566,7 @@ _, err := consumer.BQ().
 |-----------|---------|-------------|
 | `broker` | redis | Message broker implementation |
 | `consumerPoolSize` | 10 | Number of concurrent consumers; for Sequence Queue, worker goroutines per instance |
+| `consumerReaderPoolSize` | 8 | Partition reader goroutines per registered consumer; the effective count never exceeds the partition count |
 | `jobMaxRetries` | 3 | Maximum retry attempts for failed jobs |
 | `deadLetterIdle` | 60s | Pending idle before DLQ for regular queues; token lease and `XAUTOCLAIM` threshold for Sequence Queue |
 | `deadLetterTicker` | 5s | Interval for scanning dead-letter candidates |

--- a/README.md
+++ b/README.md
@@ -601,6 +601,10 @@ _, err := consumer.BQ().
 | `redis.readTimeout` | 0 | Redis read timeout |
 | `redis.writeTimeout` | 0 | Redis write timeout |
 | `redis.poolTimeout` | 0 | Timeout for waiting on a pooled Redis connection |
+| `redis.waitReplicas` | 0 | Number of replicas that must acknowledge each published message; 0 disables `WAIT` |
+| `redis.waitTimeout` | 1s when enabled | Maximum time Redis waits for replica acknowledgements; a timeout fails the publish |
+
+When `redis.waitReplicas` is enabled, BeanQ routes each publish to the master that owns the message key and executes the write and `WAIT` on the same connection. This also applies to Redis Cluster. If replica acknowledgements are insufficient, publishing returns `ErrAmbiguousCommit`: the primary write may already exist and must not be retried blindly.
 
 ### Redis SSL Parameters
 

--- a/broker_validator.go
+++ b/broker_validator.go
@@ -1,0 +1,63 @@
+package beanq
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/retail-ai-inc/beanq/v4/helper/berror"
+)
+
+// BrokerConfigValidator validates the broker-specific section of a BeanqConfig.
+type BrokerConfigValidator func(*BeanqConfig) error
+
+var registeredBrokerConfigValidators = struct {
+	sync.RWMutex
+	values map[string]BrokerConfigValidator
+}{
+	values: map[string]BrokerConfigValidator{
+		"redis": func(config *BeanqConfig) error {
+			return config.validateRedis()
+		},
+	},
+}
+
+// RegisterBrokerConfigValidator makes a broker-specific configuration validator
+// available to BeanqConfig.Validate. Broker names are case-insensitive.
+func RegisterBrokerConfigValidator(name string, validator BrokerConfigValidator) error {
+	name = normalizeBrokerName(name)
+	if name == "" {
+		return errors.New("broker validator name is required")
+	}
+	if validator == nil {
+		return errors.New("broker config validator is required")
+	}
+
+	registeredBrokerConfigValidators.Lock()
+	defer registeredBrokerConfigValidators.Unlock()
+	if _, exists := registeredBrokerConfigValidators.values[name]; exists {
+		return fmt.Errorf("broker config validator %q is already registered", name)
+	}
+	registeredBrokerConfigValidators.values[name] = validator
+	return nil
+}
+
+func validateRegisteredBrokerConfig(config *BeanqConfig) error {
+	name := normalizeBrokerName(config.Broker)
+	if name == "" {
+		return berror.ErrInvalidConfig.WithMessage("broker is required")
+	}
+
+	registeredBrokerConfigValidators.RLock()
+	validator, exists := registeredBrokerConfigValidators.values[name]
+	registeredBrokerConfigValidators.RUnlock()
+	if !exists {
+		return berror.ErrUnsupportedBroker.WithMessage(config.Broker)
+	}
+	return validator(config)
+}
+
+func normalizeBrokerName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}

--- a/broker_validator_test.go
+++ b/broker_validator_test.go
@@ -1,0 +1,62 @@
+package beanq_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	beanq "github.com/retail-ai-inc/beanq/v4"
+)
+
+var validatorTestID atomic.Int64
+
+func TestRegisterBrokerConfigValidator(t *testing.T) {
+	broker := fmt.Sprintf("external-validator-test-%d", validatorTestID.Add(1))
+	configuredBroker := " " + strings.ToUpper(broker) + " "
+	sentinel := errors.New("external validator called")
+	if err := beanq.RegisterBrokerConfigValidator(configuredBroker, func(config *beanq.BeanqConfig) error {
+		if config.Broker != configuredBroker {
+			t.Fatalf("validator received unexpected broker %q", config.Broker)
+		}
+		return sentinel
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &beanq.BeanqConfig{Broker: configuredBroker}
+	if err := cfg.Validate(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected external validator error, got %v", err)
+	}
+	if err := beanq.RegisterBrokerConfigValidator(broker, func(*beanq.BeanqConfig) error { return nil }); err == nil ||
+		!strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("expected duplicate registration error, got %v", err)
+	}
+}
+
+func TestBrokerConfigValidatorConcurrentAccess(t *testing.T) {
+	broker := fmt.Sprintf("concurrent-validator-test-%d", validatorTestID.Add(1))
+	var calls atomic.Int64
+	if err := beanq.RegisterBrokerConfigValidator(broker, func(*beanq.BeanqConfig) error {
+		calls.Add(1)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 32
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Go(func() {
+			if err := (&beanq.BeanqConfig{Broker: broker}).Validate(); err != nil {
+				t.Errorf("validate: %v", err)
+			}
+		})
+	}
+	wait.Wait()
+	if calls.Load() != workers {
+		t.Fatalf("validator calls = %d, want %d", calls.Load(), workers)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -39,7 +39,6 @@ import (
 	"github.com/retail-ai-inc/beanq/v4/helper/logger"
 	"github.com/retail-ai-inc/beanq/v4/helper/timex"
 	public "github.com/retail-ai-inc/beanq/v4/internal"
-	"github.com/retail-ai-inc/beanq/v4/internal/boptions"
 	"github.com/retail-ai-inc/beanq/v4/internal/btype"
 	"github.com/retail-ai-inc/beanq/v4/internal/capture"
 	"github.com/retail-ai-inc/beanq/v4/internal/driver/bredis"
@@ -185,6 +184,8 @@ type (
 
 	// Client is BeanQ's root client.
 	Client struct {
+		closeOnce        sync.Once
+		closeErr         error
 		captureException func(ctx context.Context, err any)
 		broker           Broker
 		driver           any
@@ -214,25 +215,46 @@ type (
 	RetryConditionFunc func(map[string]any, error) bool
 )
 
-func New(config *BeanqConfig, options ...ClientOption) *Client {
-	config.init()
+func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
+	c.closeOnce.Do(func() {
+		if closer, ok := c.broker.(interface{ Close() error }); ok {
+			c.closeErr = closer.Close()
+		}
+	})
+	return c.closeErr
+}
 
-	client := newClientFromConfig(config)
+func New(config *BeanqConfig, options ...ClientOption) *Client {
+	if config == nil {
+		logger.New().Panic("new client err:", berror.ErrInvalidConfig.WithMessage("config is nil"))
+	}
+	candidate := ResolvedConfig{BeanqConfig: cloneBeanqConfig(*config)}
+	candidate.ApplyDefaults()
+
+	client := newClientFromConfig(&candidate.BeanqConfig)
 	for _, option := range options {
 		option(client)
 	}
 	if client.broker == nil {
-		client.broker, client.captureConfig = newBrokerFromConfig(config)
+		resolved, err := config.Resolve()
+		if err != nil {
+			logger.New().Panic("new client err:", err)
+		}
+		candidate = resolved
+		client.broker, client.captureConfig = newBrokerFromConfig(candidate)
 	}
 	setBrokerDriver(client.broker)
 	if provider, ok := client.broker.(driverProvider); ok {
 		client.driver = provider.Driver()
 	}
-	client.config = config
+	client.config = &candidate.BeanqConfig
 	return client
 }
 
-func newBrokerFromConfig(config *BeanqConfig) (Broker, *capture.Config) {
+func newBrokerFromConfig(config ResolvedConfig) (Broker, *capture.Config) {
 	switch config.Broker {
 	case "redis":
 		return newRedisBroker(config)
@@ -242,20 +264,13 @@ func newBrokerFromConfig(config *BeanqConfig) (Broker, *capture.Config) {
 	}
 }
 
-func newRedisBroker(config *BeanqConfig) (Broker, *capture.Config) {
-	cfg := config.Redis
-	driver, err := bredis.NewRdb(cfg.IsCluster, cfg.Host, cfg.Port, cfg.Username,
-		cfg.Password, cfg.Database,
-		cfg.MaxRetries, cfg.DialTimeout, cfg.ReadTimeout, cfg.WriteTimeout, cfg.PoolTimeout, cfg.PoolSize, cfg.MinIdleConnections,
-		cfg.SSL.On, cfg.SSL.CAFile, cfg.SSL.Verify, cfg.SSL.HotReload, cfg.WaitReplicas)
+func newRedisBroker(config ResolvedConfig) (Broker, *capture.Config) {
+	driver, err := bredis.NewRedisClient(context.Background(), config.redisClientOptions())
 	if err != nil {
 		logger.New().Panic("new broker err:", err)
 	}
 
-	sequencePartitions := boptions.ResolveSequenceQueuePartitions(config.SequenceQueuePartitions, config.MinConsumers)
-	normalPartitions := boptions.ResolveNormalQueuePartitions(config.NormalQueuePartitions, config.MinConsumers)
-	broker := bredis.NewBrokerWithRuntimePoolsAndReplicationWait(driver, cfg.Prefix, cfg.MaxLen, config.MinConsumers, normalPartitions, sequencePartitions,
-		config.ConsumerPoolSize, config.ConsumerReaderPoolSize, config.DeadLetterIdleTime, cfg.WaitReplicas, cfg.WaitTimeout)
+	broker := bredis.NewBrokerWithOptions(driver, config.redisBrokerOptions())
 
 	var captureConfig *capture.Config
 	var migrator MigrationRunner
@@ -276,11 +291,7 @@ type captureConfigReader interface {
 }
 
 func loadCaptureConfig(config *Mongo) *capture.Config {
-	collections := make(map[string]string, len(config.Collections))
-	for key, collection := range config.Collections {
-		collections[key] = collection.Name
-	}
-	store := bmongo.NewMongo(config.Host, config.Port, config.UserName, config.Password, config.Database, collections,
+	store := bmongo.NewMongo(config.Host, config.Port, config.UserName, config.Password, config.Database, config.collectionNames(),
 		config.ConnectTimeOut, config.MaxConnectionPoolSize, config.MaxConnectionLifeTime,
 		bmongo.MongoSSLConfig{On: config.SSL.On, CAFile: config.SSL.CAFile, Verify: config.SSL.Verify})
 
@@ -403,6 +414,11 @@ func (c *Client) cloneForCommand() *Client {
 }
 
 func (c *Client) Wait(ctx context.Context) {
+	defer func() {
+		if err := c.Close(); err != nil {
+			logger.New().Error(err)
+		}
+	}()
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 

--- a/client.go
+++ b/client.go
@@ -254,7 +254,8 @@ func newRedisBroker(config *BeanqConfig) (Broker, *capture.Config) {
 
 	sequencePartitions := boptions.ResolveSequenceQueuePartitions(config.SequenceQueuePartitions, config.MinConsumers)
 	normalPartitions := boptions.ResolveNormalQueuePartitions(config.NormalQueuePartitions, config.MinConsumers)
-	broker := bredis.NewBrokerWithReplicationWait(driver, cfg.Prefix, cfg.MaxLen, config.MinConsumers, normalPartitions, sequencePartitions, config.ConsumerPoolSize, config.DeadLetterIdleTime, cfg.WaitReplicas, cfg.WaitTimeout)
+	broker := bredis.NewBrokerWithRuntimePoolsAndReplicationWait(driver, cfg.Prefix, cfg.MaxLen, config.MinConsumers, normalPartitions, sequencePartitions,
+		config.ConsumerPoolSize, config.ConsumerReaderPoolSize, config.DeadLetterIdleTime, cfg.WaitReplicas, cfg.WaitTimeout)
 
 	var captureConfig *capture.Config
 	var migrator MigrationRunner

--- a/client.go
+++ b/client.go
@@ -247,14 +247,14 @@ func newRedisBroker(config *BeanqConfig) (Broker, *capture.Config) {
 	driver, err := bredis.NewRdb(cfg.IsCluster, cfg.Host, cfg.Port, cfg.Username,
 		cfg.Password, cfg.Database,
 		cfg.MaxRetries, cfg.DialTimeout, cfg.ReadTimeout, cfg.WriteTimeout, cfg.PoolTimeout, cfg.PoolSize, cfg.MinIdleConnections,
-		cfg.SSL.On, cfg.SSL.CAFile, cfg.SSL.Verify, cfg.SSL.HotReload)
+		cfg.SSL.On, cfg.SSL.CAFile, cfg.SSL.Verify, cfg.SSL.HotReload, cfg.WaitReplicas)
 	if err != nil {
 		logger.New().Panic("new broker err:", err)
 	}
 
 	sequencePartitions := boptions.ResolveSequenceQueuePartitions(config.SequenceQueuePartitions, config.MinConsumers)
 	normalPartitions := boptions.ResolveNormalQueuePartitions(config.NormalQueuePartitions, config.MinConsumers)
-	broker := bredis.NewBrokerWithPartitions(driver, cfg.Prefix, cfg.MaxLen, config.MinConsumers, normalPartitions, sequencePartitions, config.ConsumerPoolSize, config.DeadLetterIdleTime)
+	broker := bredis.NewBrokerWithReplicationWait(driver, cfg.Prefix, cfg.MaxLen, config.MinConsumers, normalPartitions, sequencePartitions, config.ConsumerPoolSize, config.DeadLetterIdleTime, cfg.WaitReplicas, cfg.WaitTimeout)
 
 	var captureConfig *capture.Config
 	var migrator MigrationRunner

--- a/client_backend_test.go
+++ b/client_backend_test.go
@@ -59,6 +59,27 @@ func (f *fakeQueueBackend) WaitingSequenceAck(_ context.Context, _, _, orderKey,
 	return f.ack, f.err
 }
 
+type closableFakeQueueBackend struct {
+	fakeQueueBackend
+	closes int
+}
+
+func (f *closableFakeQueueBackend) Close() error { f.closes++; return f.err }
+
+func TestClientCloseIsIdempotent(t *testing.T) {
+	backend := &closableFakeQueueBackend{}
+	client := &Client{broker: backend}
+	if err := client.Close(); err != nil {
+		t.Fatalf(`first Close: %v`, err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf(`second Close: %v`, err)
+	}
+	if backend.closes != 1 {
+		t.Fatalf(`broker Close calls = %d, want 1`, backend.closes)
+	}
+}
+
 func TestClientPublishUsesBackendNeutralPublisher(t *testing.T) {
 	published := make(chan map[string]any, 1)
 	b := &fakeQueueBackend{published: published}

--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/retail-ai-inc/beanq/v4/helper/logger"
 	"github.com/retail-ai-inc/beanq/v4/helper/ui"
 	"github.com/retail-ai-inc/beanq/v4/internal/boptions"
+	"github.com/retail-ai-inc/beanq/v4/internal/driver/bredis"
 	"github.com/spf13/viper"
 )
 
@@ -152,7 +153,79 @@ type (
 		ConsumerPoolSize         int           `json:"consumerPoolSize" mapstructure:"consumerPoolSize"`
 		ConsumerReaderPoolSize   int           `json:"consumerReaderPoolSize" mapstructure:"consumerReaderPoolSize"`
 	}
+	ResolvedConfig struct {
+		BeanqConfig
+	}
 )
+
+// Resolve returns a complete, validated copy without modifying the source config.
+func (t *BeanqConfig) Resolve() (ResolvedConfig, error) {
+	if t == nil {
+		return ResolvedConfig{}, berror.ErrInvalidConfig.WithMessage("config is nil")
+	}
+	resolved := ResolvedConfig{BeanqConfig: cloneBeanqConfig(*t)}
+	resolved.ApplyDefaults()
+	if err := resolved.Validate(); err != nil {
+		return ResolvedConfig{}, err
+	}
+	return resolved, nil
+}
+
+func cloneBeanqConfig(config BeanqConfig) BeanqConfig {
+	if config.Mongo == nil {
+		return config
+	}
+	mongo := *config.Mongo
+	if config.Collections != nil {
+		mongo.Collections = make(map[string]Collection, len(config.Collections))
+		for key, collection := range config.Collections {
+			mongo.Collections[key] = collection
+		}
+	}
+	config.Mongo = &mongo
+	return config
+}
+
+func (t ResolvedConfig) redisBrokerOptions() bredis.BrokerOptions {
+	return bredis.BrokerOptions{
+		Prefix:                  t.Redis.Prefix,
+		MaxLen:                  t.Redis.MaxLen,
+		NormalQueuePartitions:   boptions.ResolveNormalQueuePartitions(t.NormalQueuePartitions, t.MinConsumers),
+		SequenceQueuePartitions: boptions.ResolveSequenceQueuePartitions(t.SequenceQueuePartitions, t.MinConsumers),
+		ConsumerWorkers:         t.ConsumerPoolSize,
+		ConsumerReaders:         t.ConsumerReaderPoolSize,
+		DeadLetterIdle:          t.DeadLetterIdleTime,
+		ReplicationWait: bredis.ReplicationWaitOptions{
+			Replicas: t.Redis.WaitReplicas,
+			Timeout:  t.Redis.WaitTimeout,
+		},
+	}
+}
+
+func (t ResolvedConfig) redisClientOptions() bredis.RedisClientOptions {
+	return bredis.RedisClientOptions{
+		IsCluster:          t.Redis.IsCluster,
+		Host:               t.Redis.Host,
+		Port:               t.Redis.Port,
+		Username:           t.Redis.Username,
+		Password:           t.Redis.Password,
+		Database:           t.Redis.Database,
+		MaxRetries:         t.Redis.MaxRetries,
+		DialTimeout:        t.Redis.DialTimeout,
+		ReadTimeout:        t.Redis.ReadTimeout,
+		WriteTimeout:       t.Redis.WriteTimeout,
+		PoolTimeout:        t.Redis.PoolTimeout,
+		PoolSize:           t.Redis.PoolSize,
+		MinIdleConnections: t.Redis.MinIdleConnections,
+		TLS: bredis.RedisTLSOptions{
+			On:                t.Redis.SSL.On,
+			CAFile:            t.Redis.SSL.CAFile,
+			VerifyCertificate: t.Redis.SSL.Verify,
+			HotReload:         t.Redis.SSL.HotReload,
+		},
+		WaitReplicas: t.Redis.WaitReplicas,
+	}
+}
 
 func (t *BeanqConfig) init() {
 	t.ApplyDefaults()
@@ -256,6 +329,27 @@ func defaultMongoCollections() map[string]Collection {
 		"role":     {Name: "roles", Shard: false},
 		"tenant":   {Name: "tenants", Shard: false},
 	}
+}
+
+func (t *Mongo) collectionNames() map[string]string {
+	if t == nil {
+		return nil
+	}
+	collections := make(map[string]string, len(t.Collections))
+	for key, collection := range t.Collections {
+		collections[key] = collection.Name
+	}
+	return collections
+}
+
+func (t *Mongo) collectionName(key, fallback string) string {
+	if t == nil {
+		return fallback
+	}
+	if collection, ok := t.Collections[key]; ok && collection.Name != "" {
+		return collection.Name
+	}
+	return fallback
 }
 
 func (t *BeanqConfig) Validate() error {
@@ -402,9 +496,9 @@ func LoadConfig(configPath string, configType string, configName string) (*Beanq
 	if err := vp.Unmarshal(&cfg); err != nil {
 		return nil, berror.ErrInvalidConfig.WithMessage("failed to unmarshal config").WithCause(err)
 	}
-	cfg.ApplyDefaults()
-	if err := cfg.Validate(); err != nil {
+	resolved, err := cfg.Resolve()
+	if err != nil {
 		return nil, err
 	}
-	return &cfg, nil
+	return &resolved.BeanqConfig, nil
 }

--- a/config.go
+++ b/config.go
@@ -61,6 +61,8 @@ type (
 		PoolTimeout        time.Duration `json:"poolTimeout" mapstructure:"poolTimeout"`
 		MaxRetries         int           `json:"maxRetries" mapstructure:"maxRetries"`
 		PoolSize           int           `json:"poolSize" mapstructure:"poolSize"`
+		WaitReplicas       int           `json:"waitReplicas" mapstructure:"waitReplicas"`
+		WaitTimeout        time.Duration `json:"waitTimeout" mapstructure:"waitTimeout"`
 		SSL                SSL           `json:"ssl" mapstructure:"ssl"`
 	}
 	SSL struct {
@@ -160,8 +162,15 @@ func (t *BeanqConfig) ApplyDefaults() {
 		t.Mongo = &Mongo{}
 	}
 	t.applyRuntimeDefaults()
+	t.applyRedisDefaults()
 	t.applyQueueDefaults()
 	t.applyMongoDefaults()
+}
+
+func (t *BeanqConfig) applyRedisDefaults() {
+	if t.Redis.WaitReplicas > 0 && t.Redis.WaitTimeout == 0 {
+		t.Redis.WaitTimeout = time.Second
+	}
 }
 
 func (t *BeanqConfig) applyRuntimeDefaults() {
@@ -249,11 +258,8 @@ func (t *BeanqConfig) Validate() error {
 	if t == nil {
 		return berror.ErrInvalidConfig.WithMessage("config is nil")
 	}
-	if strings.TrimSpace(t.Broker) == "" {
+	if normalizeBrokerName(t.Broker) == "" {
 		return berror.ErrInvalidConfig.WithMessage("broker is required")
-	}
-	if t.Broker != "redis" {
-		return berror.ErrUnsupportedBroker.WithMessage(t.Broker)
 	}
 	if t.SequenceQueuePartitions < 0 {
 		return berror.ErrInvalidConfig.WithMessage("sequenceQueuePartitions must not be negative")
@@ -261,7 +267,7 @@ func (t *BeanqConfig) Validate() error {
 	if t.NormalQueuePartitions < 0 {
 		return berror.ErrInvalidConfig.WithMessage("normalQueuePartitions must not be negative")
 	}
-	if err := t.validateRedis(); err != nil {
+	if err := validateRegisteredBrokerConfig(t); err != nil {
 		return err
 	}
 	if t.requiresMongo() {
@@ -271,8 +277,20 @@ func (t *BeanqConfig) Validate() error {
 }
 
 func (t *BeanqConfig) validateRedis() error {
+	if t.Redis.WaitReplicas < 0 {
+		return berror.ErrInvalidConfig.WithMessage("redis.waitReplicas must not be negative")
+	}
+	if t.Redis.WaitTimeout < 0 {
+		return berror.ErrInvalidConfig.WithMessage("redis.waitTimeout must not be negative")
+	}
 	if strings.TrimSpace(t.Redis.Host) == "" {
 		return berror.ErrInvalidConfig.WithMessage("redis.host is required")
+	}
+	if t.Redis.IsCluster && t.Redis.Database != 0 {
+		return berror.ErrInvalidConfig.WithMessage("redis.database must be 0 when redis.isCluster is true")
+	}
+	if !t.Redis.IsCluster && len(strings.Split(t.Redis.Host, ",")) > 1 {
+		return berror.ErrInvalidConfig.WithMessage("multiple redis addresses require redis.isCluster=true")
 	}
 	if strings.TrimSpace(t.Redis.Port) == "" && !redisHostsIncludePorts(t.Redis.Host) {
 		return berror.ErrInvalidConfig.WithMessage("redis.port is required")

--- a/config.go
+++ b/config.go
@@ -150,6 +150,7 @@ type (
 		SequenceQueuePartitions  int64         `json:"sequenceQueuePartitions" mapstructure:"sequenceQueuePartitions"`
 		JobMaxRetries            int           `json:"jobMaxRetries" mapstructure:"jobMaxRetries"`
 		ConsumerPoolSize         int           `json:"consumerPoolSize" mapstructure:"consumerPoolSize"`
+		ConsumerReaderPoolSize   int           `json:"consumerReaderPoolSize" mapstructure:"consumerReaderPoolSize"`
 	}
 )
 
@@ -176,6 +177,9 @@ func (t *BeanqConfig) applyRedisDefaults() {
 func (t *BeanqConfig) applyRuntimeDefaults() {
 	if t.ConsumerPoolSize == 0 {
 		t.ConsumerPoolSize = boptions.DefaultOptions.ConsumerPoolSize
+	}
+	if t.ConsumerReaderPoolSize == 0 {
+		t.ConsumerReaderPoolSize = boptions.DefaultOptions.ConsumerReaderPoolSize
 	}
 	if t.JobMaxRetries < 0 {
 		t.JobMaxRetries = boptions.DefaultOptions.JobMaxRetry
@@ -266,6 +270,9 @@ func (t *BeanqConfig) Validate() error {
 	}
 	if t.NormalQueuePartitions < 0 {
 		return berror.ErrInvalidConfig.WithMessage("normalQueuePartitions must not be negative")
+	}
+	if t.ConsumerReaderPoolSize < 0 {
+		return berror.ErrInvalidConfig.WithMessage("consumerReaderPoolSize must not be negative")
 	}
 	if err := validateRegisteredBrokerConfig(t); err != nil {
 		return err

--- a/config_test.go
+++ b/config_test.go
@@ -220,6 +220,39 @@ func TestBeanqConfigRejectsNegativeNormalQueuePartitions(t *testing.T) {
 	}
 }
 
+func TestBeanqConfigConsumerReaderPoolSize(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := &BeanqConfig{}
+		cfg.ApplyDefaults()
+		if cfg.ConsumerReaderPoolSize != 8 {
+			t.Fatalf("consumerReaderPoolSize = %d, want 8", cfg.ConsumerReaderPoolSize)
+		}
+	})
+
+	t.Run("configured value", func(t *testing.T) {
+		dir := t.TempDir()
+		writeConfig(t, dir, "env", `{
+			"broker":"redis",
+			"redis":{"host":"localhost","port":"6379"},
+			"consumerReaderPoolSize":12
+		}`)
+		cfg, err := NewConfig(dir, "json", "env")
+		if err != nil {
+			t.Fatalf("NewConfig error: %v", err)
+		}
+		if cfg.ConsumerReaderPoolSize != 12 {
+			t.Fatalf("consumerReaderPoolSize = %d, want 12", cfg.ConsumerReaderPoolSize)
+		}
+	})
+
+	t.Run("negative value is invalid", func(t *testing.T) {
+		cfg := &BeanqConfig{Broker: "redis", Redis: Redis{Host: "localhost", Port: "6379"}, ConsumerReaderPoolSize: -1}
+		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "consumerReaderPoolSize") {
+			t.Fatalf("expected consumerReaderPoolSize validation error, got %v", err)
+		}
+	})
+}
+
 func TestBeanqConfigValidateMongoWhenHistoryEnabled(t *testing.T) {
 	cfg := &BeanqConfig{
 		Broker:  "redis",

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/retail-ai-inc/beanq/v4/helper/berror"
 	"github.com/spf13/viper"
@@ -142,6 +143,27 @@ func TestBeanqConfigValidateRedisRequired(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "redis.host") {
 		t.Fatalf("expected redis.host error, got %v", err)
+	}
+}
+
+func TestBeanqConfigRedisWait(t *testing.T) {
+	cfg := &BeanqConfig{Broker: "redis", Redis: Redis{Host: "localhost", Port: "6379", WaitReplicas: -1}}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "waitReplicas") {
+		t.Fatalf("expected waitReplicas validation error, got %v", err)
+	}
+	cfg.Redis.WaitReplicas = 1
+	cfg.Redis.IsCluster = true
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected cluster WAIT config to be valid, got %v", err)
+	}
+	cfg.Redis.WaitTimeout = -time.Second
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "waitTimeout") {
+		t.Fatalf("expected waitTimeout validation error, got %v", err)
+	}
+	cfg.Redis.WaitTimeout = 0
+	cfg.ApplyDefaults()
+	if cfg.Redis.WaitTimeout != time.Second {
+		t.Fatalf("waitTimeout = %v, want 1s", cfg.Redis.WaitTimeout)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -131,6 +131,37 @@ func TestBeanqConfigInitCreatesMongoDefaults(t *testing.T) {
 	}
 }
 
+func TestBeanqConfigResolveReturnsIndependentValidatedConfig(t *testing.T) {
+	source := &BeanqConfig{
+		Broker:                  "redis",
+		Redis:                   Redis{Host: "localhost", Port: "6379"},
+		MinConsumers:            7,
+		NormalQueuePartitions:   9,
+		SequenceQueuePartitions: 11,
+		Mongo:                   &Mongo{Collections: map[string]Collection{"event": {Name: "custom-events"}}},
+	}
+
+	resolved, err := source.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if source.ConsumerPoolSize != 0 || source.ConsumerReaderPoolSize != 0 {
+		t.Fatalf("Resolve modified source defaults: %#v", source)
+	}
+	resolved.Collections["event"] = Collection{Name: "resolved-events"}
+	if source.Collections["event"].Name != "custom-events" {
+		t.Fatal("Resolve did not copy nested Mongo collections")
+	}
+
+	options := resolved.redisBrokerOptions()
+	if options.NormalQueuePartitions != 9 || options.SequenceQueuePartitions != 11 {
+		t.Fatalf("resolved partitions = (%d, %d), want (9, 11)", options.NormalQueuePartitions, options.SequenceQueuePartitions)
+	}
+	if options.ConsumerWorkers == 0 || options.ConsumerReaders == 0 {
+		t.Fatalf("resolved runtime pools were not defaulted: %#v", options)
+	}
+}
+
 func TestBeanqConfigValidateRedisRequired(t *testing.T) {
 	cfg := &BeanqConfig{Broker: "redis"}
 	cfg.ApplyDefaults()
@@ -194,29 +225,28 @@ func TestBeanqConfigSequenceQueuePartitions(t *testing.T) {
 		}
 	})
 
-	t.Run("negative value is invalid", func(t *testing.T) {
-		cfg := &BeanqConfig{
-			Broker:                  "redis",
-			Redis:                   Redis{Host: "localhost", Port: "6379"},
-			SequenceQueuePartitions: -1,
-		}
-		err := cfg.Validate()
-		if err == nil {
-			t.Fatal("expected validation error")
-		}
-		if !errors.Is(err, berror.ErrInvalidConfig) {
-			t.Fatalf("expected ErrInvalidConfig, got %v", err)
-		}
-		if !strings.Contains(err.Error(), "sequenceQueuePartitions") {
-			t.Fatalf("expected sequenceQueuePartitions error, got %v", err)
-		}
-	})
 }
 
-func TestBeanqConfigRejectsNegativeNormalQueuePartitions(t *testing.T) {
-	cfg := &BeanqConfig{Broker: "redis", Redis: Redis{Host: "localhost", Port: "6379"}, NormalQueuePartitions: -1}
-	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "normalQueuePartitions") {
-		t.Fatalf("expected normalQueuePartitions validation error, got %v", err)
+func TestBeanqConfigRuntimeValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*BeanqConfig)
+		message string
+	}{
+		{name: "sequence queue partitions", mutate: func(cfg *BeanqConfig) { cfg.SequenceQueuePartitions = -1 }, message: "sequenceQueuePartitions"},
+		{name: "normal queue partitions", mutate: func(cfg *BeanqConfig) { cfg.NormalQueuePartitions = -1 }, message: "normalQueuePartitions"},
+		{name: "consumer reader pool", mutate: func(cfg *BeanqConfig) { cfg.ConsumerReaderPoolSize = -1 }, message: "consumerReaderPoolSize"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &BeanqConfig{Broker: "redis", Redis: Redis{Host: "localhost", Port: "6379"}}
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			if err == nil || !errors.Is(err, berror.ErrInvalidConfig) || !strings.Contains(err.Error(), tt.message) {
+				t.Fatalf("expected ErrInvalidConfig containing %q, got %v", tt.message, err)
+			}
+		})
 	}
 }
 
@@ -245,12 +275,6 @@ func TestBeanqConfigConsumerReaderPoolSize(t *testing.T) {
 		}
 	})
 
-	t.Run("negative value is invalid", func(t *testing.T) {
-		cfg := &BeanqConfig{Broker: "redis", Redis: Redis{Host: "localhost", Port: "6379"}, ConsumerReaderPoolSize: -1}
-		if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "consumerReaderPoolSize") {
-			t.Fatalf("expected consumerReaderPoolSize validation error, got %v", err)
-		}
-	})
 }
 
 func TestBeanqConfigValidateMongoWhenHistoryEnabled(t *testing.T) {

--- a/env.json
+++ b/env.json
@@ -56,7 +56,9 @@
     "dialTimeout": "5s",
     "readTimeout": "3s",
     "writeTimeout": "3s",
-    "poolTimeout": "4s"
+    "poolTimeout": "4s",
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "broker": "redis",
   "consumerPoolSize": 10,

--- a/env.json
+++ b/env.json
@@ -62,6 +62,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 10,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "60s",
   "jobMaxRetries": 3,
   "keepFailedJobsInHistory": "3600s",

--- a/env.testing.json
+++ b/env.testing.json
@@ -63,6 +63,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 10,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "60s",
   "jobMaxRetries": 3,
   "keepFailedJobsInHistory": "3600s",

--- a/env.testing.json
+++ b/env.testing.json
@@ -57,7 +57,9 @@
     "readTimeout": "3s",
     "writeTimeout": "3s",
     "poolTimeout": "4s",
-    "maxLen": 1000
+    "maxLen": 1000,
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "broker": "redis",
   "consumerPoolSize": 10,

--- a/examples/delay/env.json
+++ b/examples/delay/env.json
@@ -34,6 +34,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 10,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "3600s",
   "jobMaxRetries": 1,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/delay/env.json
+++ b/examples/delay/env.json
@@ -24,7 +24,9 @@
     "readTimeout": "3s",
     "writeTimeout": "3s",
     "poolTimeout": "4s",
-    "maxLen": 1000
+    "maxLen": 1000,
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "health": {
     "port": "7777",

--- a/examples/migrate/env.json
+++ b/examples/migrate/env.json
@@ -23,7 +23,9 @@
     "readTimeout": "3s",
     "writeTimeout": "3s",
     "poolTimeout": "4s",
-    "maxLen":1000
+    "maxLen":1000,
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "health": {
     "port": "7777",

--- a/examples/migrate/env.json
+++ b/examples/migrate/env.json
@@ -33,6 +33,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 10,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "3600s",
   "jobMaxRetries": 1,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/normal/env.json
+++ b/examples/normal/env.json
@@ -34,6 +34,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 10,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "3600s",
   "jobMaxRetries": 1,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/normal/env.json
+++ b/examples/normal/env.json
@@ -24,7 +24,9 @@
     "readTimeout": "3s",
     "writeTimeout": "3s",
     "poolTimeout": "4s",
-    "maxLen": 1000
+    "maxLen": 1000,
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "health": {
     "port": "7777",

--- a/examples/sequence-queue/README.md
+++ b/examples/sequence-queue/README.md
@@ -5,6 +5,7 @@ This example verifies the new sequence queue API:
 - `PublishNewSequence(channel, topic, orderKey, payload)` publishes interleaved messages for multiple `orderKey` values.
 - `ConsumerSequence(channel, topic, handle)` keeps FIFO order inside each `orderKey` list while allowing different `orderKey` values to run in parallel.
 - `sequenceQueuePartitions` fixes the number of Redis Cluster scheduler streams. It must remain identical across publishers and consumers after the queue is created.
+- `consumerReaderPoolSize` controls the bounded partition reader pool per consumer. Readers divide partitions by stride; they are not created per partition. For example, 1,000 partitions with a pool size of 8 starts 8 resident readers, not 8,000 goroutines.
 - Delivery is at-least-once: handlers should be idempotent by message ID. A worker crash may repeat the current message, but a stale owner cannot advance the Redis queue state.
 
 Run the consumer first:

--- a/examples/sequence-queue/README.md
+++ b/examples/sequence-queue/README.md
@@ -22,3 +22,18 @@ go run ./examples/sequence-queue/publisher
 The publisher does not pass a `seq` field to the queue. Each body contains a visible marker such as `order01-message-01`. The consumer validates the visible marker for each `orderKey` and prints the received message. FIFO execution is provided by the sequence queue itself.
 
 This example publishes 10 `orderKey` values. `order01` has 5 messages, `order03` has 3 messages, and the other order keys have 1 message each. Expected normal output contains increasing body markers per `orderKey`, for example `order01-message-01`, `order01-message-02`, and so on. Messages from different `orderKey` values may appear interleaved.
+
+## Replica acknowledgement with Redis WAIT
+
+Set `redis.waitReplicas` to a positive value to require replica acknowledgement for critical Sequence Queue state transitions. BeanQ executes Enqueue, Acquire, Renew, and Finalize Lua writes followed by one Redis `WAIT` on the same connection to the partition master. `redis.waitTimeout` limits how long Redis waits for the configured number of replicas.
+
+```json
+{
+  "redis": {
+    "waitReplicas": 1,
+    "waitTimeout": "1s"
+  }
+}
+```
+
+BeanQ validates at startup that every relevant master has at least `waitReplicas` online replicas. If `WAIT` times out or acknowledges too few replicas, the operation returns an ambiguous-commit error: the primary write may already have succeeded, so callers must not retry it blindly. `WAIT` confirms receipt by replicas; it does not guarantee disk persistence. Leave `waitReplicas` at `0` to disable this behavior without adding a `WAIT` round trip.

--- a/examples/sequence-queue/env.json
+++ b/examples/sequence-queue/env.json
@@ -34,6 +34,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 8,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "3600s",
   "jobMaxRetries": 0,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/sequence-queue/env.json
+++ b/examples/sequence-queue/env.json
@@ -24,7 +24,9 @@
     "readTimeout": "3s",
     "writeTimeout": "3s",
     "poolTimeout": "4s",
-    "maxLen": 1000
+    "maxLen": 1000,
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "health": {
     "port": "7777",

--- a/examples/ui/env-redis-cluster.json
+++ b/examples/ui/env-redis-cluster.json
@@ -37,6 +37,7 @@
     "path": ""
   },
   "redis": {
+    "isCluster": true,
     "host": "127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004,127.0.0.1:7005,127.0.0.1:7006",
     "port": "6379",
     "password": "secret",
@@ -48,7 +49,9 @@
     "dialTimeout": "5s",
     "readTimeout": "3s",
     "writeTimeout": "3s",
-    "poolTimeout": "4s"
+    "poolTimeout": "4s",
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "broker": "redis",
   "consumerPoolSize": 100,

--- a/examples/ui/env-redis-cluster.json
+++ b/examples/ui/env-redis-cluster.json
@@ -55,6 +55,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 100,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "60s",
   "jobMaxRetries": 1,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/ui/env.json
+++ b/examples/ui/env.json
@@ -57,7 +57,9 @@
     "readTimeout": "3s",
     "writeTimeout": "3s",
     "poolTimeout": "4s",
-    "maxLen": 1000
+    "maxLen": 1000,
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "broker": "redis",
   "consumerPoolSize": 100,

--- a/examples/ui/env.json
+++ b/examples/ui/env.json
@@ -63,6 +63,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 100,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "60s",
   "jobMaxRetries": 1,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/workflow/env.json
+++ b/examples/workflow/env.json
@@ -54,6 +54,7 @@
   },
   "broker": "redis",
   "consumerPoolSize": 100,
+  "consumerReaderPoolSize": 8,
   "deadLetterIdle": "60s",
   "jobMaxRetries": 1,
   "keepFailedJobsInHistory": "3600s",

--- a/examples/workflow/env.json
+++ b/examples/workflow/env.json
@@ -48,7 +48,9 @@
     "dialTimeout": "5s",
     "readTimeout": "3s",
     "writeTimeout": "3s",
-    "poolTimeout": "4s"
+    "poolTimeout": "4s",
+    "waitReplicas": 0,
+    "waitTimeout": "1s"
   },
   "broker": "redis",
   "consumerPoolSize": 100,

--- a/internal/boptions/options.go
+++ b/internal/boptions/options.go
@@ -40,6 +40,7 @@ type Options struct {
 	DefaultChannel           string
 	Prefix                   string
 	ConsumerPoolSize         int
+	ConsumerReaderPoolSize   int
 	Priority                 float64
 	JobMaxRetry              int
 	DefaultMaxLen            int64
@@ -81,6 +82,7 @@ var DefaultOptions = &Options{
 	PublishTimeOut:           10 * time.Second,
 	ConsumeTimeOut:           20 * time.Second,
 	ConsumerPoolSize:         10,
+	ConsumerReaderPoolSize:   8,
 	MinConsumers:             100,
 	TimeToRun:                3600 * time.Second,
 	JobMaxRetry:              3,

--- a/internal/driver/bredis/broker.go
+++ b/internal/driver/bredis/broker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/retail-ai-inc/beanq/v4/helper/berror"
 	"github.com/retail-ai-inc/beanq/v4/helper/bstatus"
 	public "github.com/retail-ai-inc/beanq/v4/internal"
+	"github.com/retail-ai-inc/beanq/v4/internal/boptions"
 	"github.com/retail-ai-inc/beanq/v4/internal/btype"
 	"github.com/retail-ai-inc/beanq/v4/internal/capture"
 	"github.com/spf13/cast"
@@ -54,15 +55,28 @@ func NewBrokerWithPartitions(client redis.UniversalClient, prefix string, maxLen
 }
 
 func NewBrokerWithReplicationWait(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize int, duration time.Duration, waitReplicas int, waitTimeout time.Duration) *Broker {
+	return NewBrokerWithRuntimePoolsAndReplicationWait(client, prefix, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions,
+		consumerPoolSize, boptions.DefaultOptions.ConsumerReaderPoolSize, duration, waitReplicas, waitTimeout)
+}
+
+// NewBrokerWithRuntimePoolsAndReplicationWait constructs a broker with independently
+// configurable message worker and partition reader pools.
+func NewBrokerWithRuntimePoolsAndReplicationWait(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize, consumerReaderPoolSize int, duration time.Duration, waitReplicas int, waitTimeout time.Duration) *Broker {
 	wait := replicationWait{replicas: waitReplicas, timeout: waitTimeout}
 	normal := func(config *capture.Config) *Normal {
-		return newNormalWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
+		queue := newNormalWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
+		queue.base.consumerReaderPoolSize = consumerReaderPoolSize
+		return queue
 	}
 	delay := func(config *capture.Config) *Schedule {
-		return newScheduleWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
+		queue := newScheduleWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
+		queue.base.consumerReaderPoolSize = consumerReaderPoolSize
+		return queue
 	}
 	sequenceQueue := func(config *capture.Config) *SequenceQueue {
-		return newSequenceQueueWithPartitionsAndWait(client, prefix, maxLen, sequenceQueuePartitions, consumerPoolSize, duration, config, wait)
+		queue := newSequenceQueueWithPartitionsAndWait(client, prefix, maxLen, sequenceQueuePartitions, consumerPoolSize, duration, config, wait)
+		queue.base.consumerReaderPoolSize = consumerReaderPoolSize
+		return queue
 	}
 	routes := map[btype.MoodType]queueRoute{
 		btype.NORMAL: routeFromQueue(normal(nil).Publish, func(config *capture.Config) consumeFunc { return normal(config).Consume }),

--- a/internal/driver/bredis/broker.go
+++ b/internal/driver/bredis/broker.go
@@ -25,6 +25,22 @@ type Broker struct {
 	captureConfig *capture.Config
 }
 
+type BrokerOptions struct {
+	Prefix                  string
+	MaxLen                  int64
+	NormalQueuePartitions   int64
+	SequenceQueuePartitions int64
+	ConsumerWorkers         int
+	ConsumerReaders         int
+	DeadLetterIdle          time.Duration
+	ReplicationWait         ReplicationWaitOptions
+}
+
+type ReplicationWaitOptions struct {
+	Replicas int
+	Timeout  time.Duration
+}
+
 type Consumer interface {
 	Consume(ctx context.Context, channel, topic string, handler public.CallbackWithRetry)
 }
@@ -40,43 +56,81 @@ type queueRoute struct {
 	consume func(config *capture.Config) Consumer
 }
 
+// NewBroker constructs a broker using one partition per configured consumer.
+// Deprecated: use NewBrokerWithOptions.
 func NewBroker(client redis.UniversalClient, prefix string, maxLen, consumers int64, consumerPoolSize int, duration time.Duration) *Broker {
-	return NewBrokerWithPartitions(client, prefix, maxLen, consumers, consumers, consumers, consumerPoolSize, duration)
+	return NewBrokerWithOptions(client, BrokerOptions{
+		Prefix: prefix, MaxLen: maxLen,
+		NormalQueuePartitions: consumers, SequenceQueuePartitions: consumers,
+		ConsumerWorkers: consumerPoolSize, DeadLetterIdle: duration,
+	})
 }
 
 // NewBrokerWithSequenceQueuePartitions constructs a broker with a fixed
 // sequence-queue partition count. The topology is immutable after construction.
+// Deprecated: use NewBrokerWithOptions.
 func NewBrokerWithSequenceQueuePartitions(client redis.UniversalClient, prefix string, maxLen, consumers, sequenceQueuePartitions int64, consumerPoolSize int, duration time.Duration) *Broker {
-	return NewBrokerWithPartitions(client, prefix, maxLen, consumers, consumers, sequenceQueuePartitions, consumerPoolSize, duration)
+	return NewBrokerWithOptions(client, BrokerOptions{
+		Prefix: prefix, MaxLen: maxLen,
+		NormalQueuePartitions: consumers, SequenceQueuePartitions: sequenceQueuePartitions,
+		ConsumerWorkers: consumerPoolSize, DeadLetterIdle: duration,
+	})
 }
 
+// NewBrokerWithPartitions constructs a broker with explicit queue partition counts.
+// Deprecated: use NewBrokerWithOptions.
 func NewBrokerWithPartitions(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize int, duration time.Duration) *Broker {
-	return NewBrokerWithReplicationWait(client, prefix, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions, consumerPoolSize, duration, 0, 0)
+	return NewBrokerWithOptions(client, BrokerOptions{
+		Prefix: prefix, MaxLen: maxLen,
+		NormalQueuePartitions: normalQueuePartitions, SequenceQueuePartitions: sequenceQueuePartitions,
+		ConsumerWorkers: consumerPoolSize, DeadLetterIdle: duration,
+	})
 }
 
+// NewBrokerWithReplicationWait constructs a broker with Redis WAIT settings.
+// Deprecated: use NewBrokerWithOptions.
 func NewBrokerWithReplicationWait(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize int, duration time.Duration, waitReplicas int, waitTimeout time.Duration) *Broker {
-	return NewBrokerWithRuntimePoolsAndReplicationWait(client, prefix, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions,
-		consumerPoolSize, boptions.DefaultOptions.ConsumerReaderPoolSize, duration, waitReplicas, waitTimeout)
+	return NewBrokerWithOptions(client, BrokerOptions{
+		Prefix: prefix, MaxLen: maxLen,
+		NormalQueuePartitions: normalQueuePartitions, SequenceQueuePartitions: sequenceQueuePartitions,
+		ConsumerWorkers: consumerPoolSize, ConsumerReaders: boptions.DefaultOptions.ConsumerReaderPoolSize,
+		DeadLetterIdle: duration, ReplicationWait: ReplicationWaitOptions{Replicas: waitReplicas, Timeout: waitTimeout},
+	})
 }
 
 // NewBrokerWithRuntimePoolsAndReplicationWait constructs a broker with independently
 // configurable message worker and partition reader pools.
+// Deprecated: use NewBrokerWithOptions.
 func NewBrokerWithRuntimePoolsAndReplicationWait(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize, consumerReaderPoolSize int, duration time.Duration, waitReplicas int, waitTimeout time.Duration) *Broker {
-	wait := replicationWait{replicas: waitReplicas, timeout: waitTimeout}
+	return NewBrokerWithOptions(client, BrokerOptions{
+		Prefix: prefix, MaxLen: maxLen,
+		NormalQueuePartitions: normalQueuePartitions, SequenceQueuePartitions: sequenceQueuePartitions,
+		ConsumerWorkers: consumerPoolSize, ConsumerReaders: consumerReaderPoolSize,
+		DeadLetterIdle: duration, ReplicationWait: ReplicationWaitOptions{Replicas: waitReplicas, Timeout: waitTimeout},
+	})
+}
+
+// NewBrokerWithOptions is the canonical broker constructor.
+func NewBrokerWithOptions(client redis.UniversalClient, options BrokerOptions) *Broker {
+	if options.ConsumerReaders == 0 {
+		options.ConsumerReaders = boptions.DefaultOptions.ConsumerReaderPoolSize
+	}
+	wait := replicationWait{replicas: options.ReplicationWait.Replicas, timeout: options.ReplicationWait.Timeout}
+	queue := func(partitions int64, config *capture.Config) queueOptions {
+		return queueOptions{
+			client: client, prefix: options.Prefix, maxLen: options.MaxLen, partitions: partitions,
+			runtime:        queueRuntimeOptions{workers: options.ConsumerWorkers, readers: options.ConsumerReaders},
+			deadLetterIdle: options.DeadLetterIdle, captureConfig: config, wait: wait,
+		}
+	}
 	normal := func(config *capture.Config) *Normal {
-		queue := newNormalWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
-		queue.base.consumerReaderPoolSize = consumerReaderPoolSize
-		return queue
+		return newNormalWithOptions(queue(options.NormalQueuePartitions, config))
 	}
 	delay := func(config *capture.Config) *Schedule {
-		queue := newScheduleWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
-		queue.base.consumerReaderPoolSize = consumerReaderPoolSize
-		return queue
+		return newScheduleWithOptions(queue(options.NormalQueuePartitions, config))
 	}
 	sequenceQueue := func(config *capture.Config) *SequenceQueue {
-		queue := newSequenceQueueWithPartitionsAndWait(client, prefix, maxLen, sequenceQueuePartitions, consumerPoolSize, duration, config, wait)
-		queue.base.consumerReaderPoolSize = consumerReaderPoolSize
-		return queue
+		return newSequenceQueueWithOptions(queue(options.SequenceQueuePartitions, config))
 	}
 	routes := map[btype.MoodType]queueRoute{
 		btype.NORMAL: routeFromQueue(normal(nil).Publish, func(config *capture.Config) consumeFunc { return normal(config).Consume }),
@@ -87,11 +141,11 @@ func NewBrokerWithRuntimePoolsAndReplicationWait(client redis.UniversalClient, p
 	}
 	return &Broker{
 		client:        client,
-		prefix:        prefix,
+		prefix:        options.Prefix,
 		routes:        routes,
-		publishLogger: NewProcessLogWithPartitions(client, prefix, normalQueuePartitions, sequenceQueuePartitions),
-		status:        NewStatusWithPartitions(client, prefix, normalQueuePartitions, sequenceQueuePartitions),
-		admin:         NewUITool(client, prefix),
+		publishLogger: NewProcessLogWithPartitions(client, options.Prefix, options.NormalQueuePartitions, options.SequenceQueuePartitions),
+		status:        NewStatusWithPartitions(client, options.Prefix, options.NormalQueuePartitions, options.SequenceQueuePartitions),
+		admin:         NewUITool(client, options.Prefix),
 	}
 }
 
@@ -167,6 +221,13 @@ func (t *Broker) QueueMessage(ctx context.Context) error {
 
 func (t *Broker) Driver() any {
 	return t.client
+}
+
+func (t *Broker) Close() error {
+	if t == nil || t.client == nil {
+		return nil
+	}
+	return t.client.Close()
 }
 
 type processLogger interface {

--- a/internal/driver/bredis/broker.go
+++ b/internal/driver/bredis/broker.go
@@ -50,14 +50,19 @@ func NewBrokerWithSequenceQueuePartitions(client redis.UniversalClient, prefix s
 }
 
 func NewBrokerWithPartitions(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize int, duration time.Duration) *Broker {
+	return NewBrokerWithReplicationWait(client, prefix, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions, consumerPoolSize, duration, 0, 0)
+}
+
+func NewBrokerWithReplicationWait(client redis.UniversalClient, prefix string, maxLen, consumers, normalQueuePartitions, sequenceQueuePartitions int64, consumerPoolSize int, duration time.Duration, waitReplicas int, waitTimeout time.Duration) *Broker {
+	wait := replicationWait{replicas: waitReplicas, timeout: waitTimeout}
 	normal := func(config *capture.Config) *Normal {
-		return newNormalWithPartitions(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config)
+		return newNormalWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
 	}
 	delay := func(config *capture.Config) *Schedule {
-		return newScheduleWithPartitions(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config)
+		return newScheduleWithPartitionsAndWait(client, prefix, maxLen, normalQueuePartitions, consumerPoolSize, duration, config, wait)
 	}
 	sequenceQueue := func(config *capture.Config) *SequenceQueue {
-		return newSequenceQueueWithPartitions(client, prefix, maxLen, sequenceQueuePartitions, consumerPoolSize, duration, config)
+		return newSequenceQueueWithPartitionsAndWait(client, prefix, maxLen, sequenceQueuePartitions, consumerPoolSize, duration, config, wait)
 	}
 	routes := map[btype.MoodType]queueRoute{
 		btype.NORMAL: routeFromQueue(normal(nil).Publish, func(config *capture.Config) consumeFunc { return normal(config).Consume }),

--- a/internal/driver/bredis/broker.go
+++ b/internal/driver/bredis/broker.go
@@ -89,8 +89,8 @@ func NewBrokerWithRuntimePoolsAndReplicationWait(client redis.UniversalClient, p
 		client:        client,
 		prefix:        prefix,
 		routes:        routes,
-		publishLogger: NewProcessLog(client, prefix, sequenceQueuePartitions),
-		status:        NewStatus(client, prefix, sequenceQueuePartitions),
+		publishLogger: NewProcessLogWithPartitions(client, prefix, normalQueuePartitions, sequenceQueuePartitions),
+		status:        NewStatusWithPartitions(client, prefix, normalQueuePartitions, sequenceQueuePartitions),
 		admin:         NewUITool(client, prefix),
 	}
 }

--- a/internal/driver/bredis/broker_test.go
+++ b/internal/driver/bredis/broker_test.go
@@ -5,11 +5,38 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/retail-ai-inc/beanq/v4/helper/berror"
 	"github.com/retail-ai-inc/beanq/v4/helper/bstatus"
 	"github.com/retail-ai-inc/beanq/v4/internal/btype"
 )
+
+func TestNewBrokerWithOptionsWiresQueueRuntimeOptions(t *testing.T) {
+	options := queueOptions{
+		client: nil, prefix: "prefix", maxLen: 100, partitions: 7,
+		runtime:        queueRuntimeOptions{workers: 3, readers: 5},
+		deadLetterIdle: time.Minute, wait: replicationWait{replicas: 2, timeout: time.Second},
+	}
+	queues := []struct {
+		name string
+		base queueBase
+	}{
+		{name: "normal", base: newNormalWithOptions(options).base},
+		{name: "delay", base: newScheduleWithOptions(options).base},
+		{name: "sequence", base: newSequenceQueueWithOptions(options).base},
+	}
+
+	for _, queue := range queues {
+		base := queue.base
+		if base.consumerPoolSize != 3 || base.consumerReaderPoolSize != 5 {
+			t.Fatalf("%s pools = (%d, %d), want (3, 5)", queue.name, base.consumerPoolSize, base.consumerReaderPoolSize)
+		}
+		if base.wait.replicas != 2 || base.wait.timeout != time.Second {
+			t.Fatalf("%s replication wait = %#v", queue.name, base.wait)
+		}
+	}
+}
 
 func TestRdbBrokerRegistersEveryQueueMood(t *testing.T) {
 	broker := NewBrokerWithPartitions(nil, "prefix", 100, 5, 7, 11, 2, 0)

--- a/internal/driver/bredis/client.go
+++ b/internal/driver/bredis/client.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	"github.com/retail-ai-inc/beanq/v4/helper/logger"
 	"github.com/retail-ai-inc/beanq/v4/internal/driver/btls"
 )
 
@@ -20,7 +19,7 @@ func NewRdb(isCluster bool, host, port string, username, password string,
 	database, maxRetries int, dialTimeout,
 	readTimeout, writeTimeout, poolTimeout time.Duration, poolSize,
 	minIdleConns int,
-	sslOn bool, caFile string, verifyCertificate bool, hotReload bool) (redis.UniversalClient, error) {
+	sslOn bool, caFile string, verifyCertificate bool, hotReload bool, waitReplicas int) (redis.UniversalClient, error) {
 
 	redisOnce.Do(func() {
 		ctx := context.Background()
@@ -33,7 +32,12 @@ func NewRdb(isCluster bool, host, port string, username, password string,
 			maxRetries, dialTimeout, readTimeout, writeTimeout, poolTimeout, poolSize, minIdleConns,
 			sslOn, caFile, verifyCertificate)
 		if redisErr != nil {
-			logger.New().Fatal(redisErr.Error())
+			return
+		}
+		if redisErr = ValidateReplicationTopology(initCtx, redisHolder.UniversalClient, waitReplicas); redisErr != nil {
+			_ = redisHolder.Close()
+			redisHolder = nil
+			return
 		}
 		if hotReload && sslOn && caFile != "" {
 			redisErr = btls.WatchCAFile(ctx, "redis", caFile, redisHolder.Reload)

--- a/internal/driver/bredis/client.go
+++ b/internal/driver/bredis/client.go
@@ -2,50 +2,77 @@ package bredis
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/retail-ai-inc/beanq/v4/internal/driver/btls"
 )
 
-var (
-	redisOnce   sync.Once
-	redisHolder *RedisHolder
-	redisErr    error
-)
+type RedisClientOptions struct {
+	IsCluster          bool
+	Host               string
+	Port               string
+	Username           string
+	Password           string
+	Database           int
+	MaxRetries         int
+	DialTimeout        time.Duration
+	ReadTimeout        time.Duration
+	WriteTimeout       time.Duration
+	PoolTimeout        time.Duration
+	PoolSize           int
+	MinIdleConnections int
+	TLS                RedisTLSOptions
+	WaitReplicas       int
+}
 
+type RedisTLSOptions struct {
+	On                bool
+	CAFile            string
+	VerifyCertificate bool
+	HotReload         bool
+}
+
+// NewRdb preserves the legacy positional-argument API.
+// Deprecated: use NewRedisClient.
 func NewRdb(isCluster bool, host, port string, username, password string,
 	database, maxRetries int, dialTimeout,
 	readTimeout, writeTimeout, poolTimeout time.Duration, poolSize,
 	minIdleConns int,
 	sslOn bool, caFile string, verifyCertificate bool, hotReload bool, waitReplicas int) (redis.UniversalClient, error) {
 
-	redisOnce.Do(func() {
-		ctx := context.Background()
-		//Preventing latency caused by Redis Cluster network topology
-		initCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-
-		redisHolder, redisErr = NewRedisHolder(
-			initCtx, isCluster, host, port, username, password, database,
-			maxRetries, dialTimeout, readTimeout, writeTimeout, poolTimeout, poolSize, minIdleConns,
-			sslOn, caFile, verifyCertificate)
-		if redisErr != nil {
-			return
-		}
-		if redisErr = ValidateReplicationTopology(initCtx, redisHolder.UniversalClient, waitReplicas); redisErr != nil {
-			_ = redisHolder.Close()
-			redisHolder = nil
-			return
-		}
-		if hotReload && sslOn && caFile != "" {
-			redisErr = btls.WatchCAFile(ctx, "redis", caFile, redisHolder.Reload)
-			if redisErr != nil {
-				_ = redisHolder.Close()
-				redisHolder = nil
-			}
-		}
+	return NewRedisClient(context.Background(), RedisClientOptions{
+		IsCluster: isCluster, Host: host, Port: port, Username: username, Password: password,
+		Database: database, MaxRetries: maxRetries, DialTimeout: dialTimeout, ReadTimeout: readTimeout,
+		WriteTimeout: writeTimeout, PoolTimeout: poolTimeout, PoolSize: poolSize, MinIdleConnections: minIdleConns,
+		TLS:          RedisTLSOptions{On: sslOn, CAFile: caFile, VerifyCertificate: verifyCertificate, HotReload: hotReload},
+		WaitReplicas: waitReplicas,
 	})
-	return redisHolder, redisErr
+}
+
+func NewRedisClient(ctx context.Context, options RedisClientOptions) (*RedisHolder, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	initCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	holder, err := NewRedisHolderWithOptions(initCtx, options)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateReplicationTopology(initCtx, holder.UniversalClient, options.WaitReplicas); err != nil {
+		_ = holder.Close()
+		return nil, err
+	}
+	if options.TLS.HotReload && options.TLS.On && options.TLS.CAFile != "" {
+		watchCtx, stopWatching := context.WithCancel(ctx)
+		if err := btls.WatchCAFile(watchCtx, `redis`, options.TLS.CAFile, holder.Reload); err != nil {
+			stopWatching()
+			_ = holder.Close()
+			return nil, err
+		}
+		holder.watcherCancel = stopWatching
+	}
+	return holder, nil
 }

--- a/internal/driver/bredis/dead_letter.go
+++ b/internal/driver/bredis/dead_letter.go
@@ -28,6 +28,7 @@ type deadLetterProcessor struct {
 	lockKey       string
 	logicKey      string
 	idle          time.Duration
+	wait          replicationWait
 }
 
 type deadLetterMessage struct {
@@ -44,6 +45,7 @@ func (t *queueBase) DeadLetterStream(ctx context.Context, channel, topic, stream
 		lockKey:       lockKey,
 		logicKey:      tool.MakeLogicKey(t.prefix),
 		idle:          t.deadLetterIdle,
+		wait:          t.wait,
 	}
 	processor.run(ctx)
 }
@@ -96,8 +98,18 @@ func (p *deadLetterProcessor) oldestExpiredPending(ctx context.Context) (redis.X
 }
 
 func (p *deadLetterProcessor) move(ctx context.Context, pendingID string, message deadLetterMessage) error {
-	if err := p.client.XAdd(ctx, message.xAddArgs(p.streamKey, p.logicKey)).Err(); err != nil {
+	args := message.xAddArgs(p.streamKey, p.logicKey)
+	if p.wait.enabled() {
+		if _, err := p.wait.execute(ctx, p.client, args.Stream, func(pipe redis.Pipeliner) redis.Cmder {
+			return pipe.XAdd(ctx, args)
+		}); err != nil {
+			return err
+		}
+	} else if err := p.client.XAdd(ctx, args).Err(); err != nil {
 		return err
+	}
+	if p.wait.enabled() {
+		return ackAndDelete(ctx, p.client, p.wait, p.streamKey, p.channel, pendingID)
 	}
 	_, err := p.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		pipe.XAck(ctx, p.streamKey, p.channel, pendingID)

--- a/internal/driver/bredis/delay_queue_store.go
+++ b/internal/driver/bredis/delay_queue_store.go
@@ -17,13 +17,14 @@ type delayQueueStore struct {
 	client   redis.UniversalClient
 	topology delayQueueTopology
 	maxLen   int64
+	wait     replicationWait
 }
 
-func newDelayQueueStore(client redis.UniversalClient, topology delayQueueTopology, maxLen int64) *delayQueueStore {
+func newDelayQueueStore(client redis.UniversalClient, topology delayQueueTopology, maxLen int64, waits ...replicationWait) *delayQueueStore {
 	if maxLen <= 0 {
 		maxLen = partitionQueueDefaultMaxLen
 	}
-	return &delayQueueStore{client: client, topology: topology, maxLen: maxLen}
+	return &delayQueueStore{client: client, topology: topology, maxLen: maxLen, wait: firstReplicationWait(waits)}
 }
 
 func (s *delayQueueStore) metadata() partitionQueueMetadata {
@@ -31,7 +32,7 @@ func (s *delayQueueStore) metadata() partitionQueueMetadata {
 }
 
 func (s *delayQueueStore) ensureMetadata(ctx context.Context) error {
-	return ensurePartitionQueueMetadata(ctx, s.client, s.topology.metadataKey(), "delay queue", s.metadata())
+	return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "delay queue", s.metadata())
 }
 
 func (s *delayQueueStore) bootstrapGroups(ctx context.Context, group string) error {
@@ -42,7 +43,7 @@ func (s *delayQueueStore) bootstrapGroup(ctx context.Context, group string, part
 	return bootstrapPartitionGroup(ctx, s.client, group, "delay queue", partition, s.topology.streamKey(partition))
 }
 
-func (s *delayQueueStore) enqueue(ctx context.Context, data map[string]any) error {
+func (s *delayQueueStore) enqueue(ctx context.Context, data map[string]any, wait replicationWait) error {
 	messageID := cast.ToString(data["id"])
 	if messageID == "" {
 		return errors.New("delay queue message id is required")
@@ -56,7 +57,17 @@ func (s *delayQueueStore) enqueue(ctx context.Context, data map[string]any) erro
 	priority := cast.ToFloat64(data["priority"])
 	// Earlier execution times sort first; priority only orders messages within the same millisecond.
 	score := float64(executeTime.UnixMilli()) - priority/1e3
-	if err := s.client.ZAdd(ctx, s.topology.scheduledKey(partition), redis.Z{Score: score, Member: payload}).Err(); err != nil {
+	if !wait.enabled() {
+		if err := s.client.ZAdd(ctx, s.topology.scheduledKey(partition), redis.Z{Score: score, Member: payload}).Err(); err != nil {
+			return fmt.Errorf("delay partition %d zadd: %w", partition, err)
+		}
+		return nil
+	}
+	scheduled := s.topology.scheduledKey(partition)
+	_, err = wait.execute(ctx, s.client, scheduled, func(pipe redis.Pipeliner) redis.Cmder {
+		return pipe.ZAdd(ctx, scheduled, redis.Z{Score: score, Member: payload})
+	})
+	if err != nil {
 		return fmt.Errorf("delay partition %d zadd: %w", partition, err)
 	}
 	return nil
@@ -99,8 +110,16 @@ func (s *delayQueueStore) promote(ctx context.Context, partition int64, now time
 			pipe.ZRem(ctx, zset, members...)
 			return nil
 		})
+		if err != nil {
+			return err
+		}
+		if s.wait.enabled() {
+			if err := s.wait.confirm(ctx, tx); err != nil {
+				return err
+			}
+		}
 		promoted = len(decoded) > 0
-		return err
+		return nil
 	}, zset, stream)
 	if errors.Is(err, redis.TxFailedErr) {
 		return false, nil

--- a/internal/driver/bredis/delay_queue_test.go
+++ b/internal/driver/bredis/delay_queue_test.go
@@ -41,6 +41,19 @@ func TestDelayQueuePartitionKeysShareOnlyTheirOwnSlot(t *testing.T) {
 	}
 }
 
+func TestDelayQueueMessageStatusKeyUsesMessageIDPartition(t *testing.T) {
+	topology := newDelayQueueTopology("prefix", "channel", "topic", 7)
+	id := "message-01"
+	partition := topology.partition(id)
+	key := topology.messageStatusKey(partition, id)
+	if firstRedisHashTag(key) != firstRedisHashTag(topology.streamKey(partition)) {
+		t.Fatalf("status key %q does not share the stream hash tag", key)
+	}
+	if !strings.HasSuffix(key, ":status:"+id) {
+		t.Fatalf("status key = %q, want message status suffix", key)
+	}
+}
+
 func TestDelayQueueCanonicalConfigUsesPerPartitionCapacity(t *testing.T) {
 	store := newDelayQueueStore(nil, newDelayQueueTopology("p", "c", "t", 7), 123)
 	if got, want := store.metadata().canonicalConfig(), "schema=2;partitions=7;capacity=123"; got != want {

--- a/internal/driver/bredis/delay_queue_topology.go
+++ b/internal/driver/bredis/delay_queue_topology.go
@@ -28,3 +28,7 @@ func (t delayQueueTopology) streamKey(partition int64) string {
 func (t delayQueueTopology) deadLetterLockKey(partition int64) string {
 	return strings.Join([]string{t.streamKey(partition), "dead_letter_lock"}, ":")
 }
+
+func (t delayQueueTopology) messageStatusKey(partition int64, id string) string {
+	return strings.Join([]string{t.streamKey(partition), "status", id}, ":")
+}

--- a/internal/driver/bredis/normal.go
+++ b/internal/driver/bredis/normal.go
@@ -16,6 +16,7 @@ type Normal struct {
 	base       queueBase
 	maxLen     int64
 	partitions int64
+	wait       replicationWait
 }
 
 func NewNormal(client redis.UniversalClient, prefix string, maxLen int64, consumerCount int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Normal {
@@ -23,15 +24,19 @@ func NewNormal(client redis.UniversalClient, prefix string, maxLen int64, consum
 }
 
 func newNormalWithPartitions(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Normal {
+	return newNormalWithPartitionsAndWait(client, prefix, maxLen, partitions, consumerPoolSize, deadLetterIdle, config, replicationWait{})
+}
+
+func newNormalWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *Normal {
 	return &Normal{
-		maxLen: maxLen, partitions: normalizeSequenceQueuePartitionCount(partitions),
+		maxLen: maxLen, partitions: normalizeSequenceQueuePartitionCount(partitions), wait: wait,
 		base: newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-			deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config}),
+			deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait}),
 	}
 }
 
 func (t *Normal) store(channel, topic string) *normalQueueStore {
-	return newNormalQueueStore(t.base.client, newNormalQueueTopology(t.base.prefix, channel, topic, t.partitions), t.maxLen)
+	return newNormalQueueStore(t.base.client, newNormalQueueTopology(t.base.prefix, channel, topic, t.partitions), t.maxLen, t.wait)
 }
 
 func (t *Normal) Publish(ctx context.Context, data map[string]any) error {
@@ -46,7 +51,17 @@ func (t *Normal) Publish(ctx context.Context, data map[string]any) error {
 	}
 	partition := store.topology.partition(messageID)
 	args := NewZAddArgs(store.topology.streamKey(partition), "", "*", store.maxLen, 0, data)
-	if err := t.base.client.XAdd(ctx, args).Err(); err != nil {
+	if !t.wait.enabled() {
+		if err := t.base.client.XAdd(ctx, args).Err(); err != nil {
+			return fmt.Errorf("[RedisBroker.enqueue] normal partition %d xadd error: %w", partition, err)
+		}
+		return nil
+	}
+	stream := store.topology.streamKey(partition)
+	_, err := t.wait.execute(ctx, t.base.client, stream, func(pipe redis.Pipeliner) redis.Cmder {
+		return pipe.XAdd(ctx, args)
+	})
+	if err != nil {
 		return fmt.Errorf("[RedisBroker.enqueue] normal partition %d xadd error: %w", partition, err)
 	}
 	return nil

--- a/internal/driver/bredis/normal.go
+++ b/internal/driver/bredis/normal.go
@@ -24,16 +24,16 @@ func NewNormal(client redis.UniversalClient, prefix string, maxLen int64, consum
 }
 
 func newNormalWithPartitions(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Normal {
-	return newNormalWithPartitionsAndWait(client, prefix, maxLen, partitions, consumerPoolSize, deadLetterIdle, config, replicationWait{})
+	return newNormalWithOptions(queueOptions{client: client, prefix: prefix, maxLen: maxLen, partitions: partitions,
+		runtime: queueRuntimeOptions{workers: consumerPoolSize}, deadLetterIdle: deadLetterIdle, captureConfig: config})
 }
 
-func newNormalWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *Normal {
-	partitions = normalizeSequenceQueuePartitionCount(partitions)
-	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
-	base.processLogger = NewProcessLogWithPartitions(client, prefix, partitions, 0)
+func newNormalWithOptions(options queueOptions) *Normal {
+	options.partitions = normalizeSequenceQueuePartitionCount(options.partitions)
+	base := newQueueBase(options)
+	base.processLogger = NewProcessLogWithPartitions(options.client, options.prefix, options.partitions, 0)
 	return &Normal{
-		maxLen: maxLen, partitions: partitions, wait: wait, base: base,
+		maxLen: options.maxLen, partitions: options.partitions, wait: options.wait, base: base,
 	}
 }
 

--- a/internal/driver/bredis/normal.go
+++ b/internal/driver/bredis/normal.go
@@ -28,10 +28,12 @@ func newNormalWithPartitions(client redis.UniversalClient, prefix string, maxLen
 }
 
 func newNormalWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *Normal {
+	partitions = normalizeSequenceQueuePartitionCount(partitions)
+	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
+		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
+	base.processLogger = NewProcessLogWithPartitions(client, prefix, partitions, 0)
 	return &Normal{
-		maxLen: maxLen, partitions: normalizeSequenceQueuePartitionCount(partitions), wait: wait,
-		base: newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-			deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait}),
+		maxLen: maxLen, partitions: partitions, wait: wait, base: base,
 	}
 }
 

--- a/internal/driver/bredis/normal_queue_multi_instance_integration_test.go
+++ b/internal/driver/bredis/normal_queue_multi_instance_integration_test.go
@@ -55,7 +55,7 @@ func TestNormalQueueFivePublishersTenConsumers(t *testing.T) {
 	}, func(context.Context, error) {})
 
 	for consumerNumber := 0; consumerNumber < consumerCount; consumerNumber++ {
-		base := newQueueBase(queueBaseOptions{client: client, prefix: prefix, deadLetterIdle: time.Minute, consumerPoolSize: 1})
+		base := newQueueBase(queueOptions{client: client, prefix: prefix, deadLetterIdle: time.Minute, runtime: queueRuntimeOptions{workers: 1}})
 		base.processLogger = normalIntegrationProcessLogger{}
 		runtime := newNormalQueueRuntime(newNormalQueueStore(client, topology, 2000), &base)
 		consumerWait.Go(func() { runtime.run(consumerCtx, channel, topic, handler) })

--- a/internal/driver/bredis/normal_queue_store.go
+++ b/internal/driver/bredis/normal_queue_store.go
@@ -10,13 +10,14 @@ type normalQueueStore struct {
 	client   redis.UniversalClient
 	topology normalQueueTopology
 	maxLen   int64
+	wait     replicationWait
 }
 
-func newNormalQueueStore(client redis.UniversalClient, topology normalQueueTopology, maxLen int64) *normalQueueStore {
+func newNormalQueueStore(client redis.UniversalClient, topology normalQueueTopology, maxLen int64, waits ...replicationWait) *normalQueueStore {
 	if maxLen <= 0 {
 		maxLen = partitionQueueDefaultMaxLen
 	}
-	return &normalQueueStore{client: client, topology: topology, maxLen: maxLen}
+	return &normalQueueStore{client: client, topology: topology, maxLen: maxLen, wait: firstReplicationWait(waits)}
 }
 
 func (s *normalQueueStore) canonicalConfig() string {
@@ -28,7 +29,7 @@ func (s *normalQueueStore) metadata() partitionQueueMetadata {
 }
 
 func (s *normalQueueStore) ensureMetadata(ctx context.Context) error {
-	return ensurePartitionQueueMetadata(ctx, s.client, s.topology.metadataKey(), "normal queue", s.metadata())
+	return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "normal queue", s.metadata())
 }
 
 func validateNormalQueueMetadata(got, want string) error {

--- a/internal/driver/bredis/normal_queue_test.go
+++ b/internal/driver/bredis/normal_queue_test.go
@@ -30,6 +30,19 @@ func TestNormalQueueTopologyProtectsClusterHashTag(t *testing.T) {
 	}
 }
 
+func TestNormalQueueMessageStatusKeyUsesMessageIDPartition(t *testing.T) {
+	topology := newNormalQueueTopology("prefix", "channel", "topic", 7)
+	id := "message-01"
+	partition := topology.partition(id)
+	key := topology.messageStatusKey(partition, id)
+	if firstRedisHashTag(key) != firstRedisHashTag(topology.streamKey(partition)) {
+		t.Fatalf("status key %q does not share the stream hash tag", key)
+	}
+	if !strings.HasSuffix(key, ":status:"+id) {
+		t.Fatalf("status key = %q, want message status suffix", key)
+	}
+}
+
 func TestNormalQueueCanonicalConfigIncludesPerPartitionCapacity(t *testing.T) {
 	store := newNormalQueueStore(nil, newNormalQueueTopology("p", "c", "t", 7), 123)
 	if got, want := store.canonicalConfig(), "schema=2;partitions=7;capacity=123"; got != want {

--- a/internal/driver/bredis/normal_queue_topology.go
+++ b/internal/driver/bredis/normal_queue_topology.go
@@ -24,3 +24,7 @@ func (t normalQueueTopology) streamKey(partition int64) string {
 func (t normalQueueTopology) deadLetterLockKey(partition int64) string {
 	return strings.Join([]string{t.streamKey(partition), "dead_letter_lock"}, ":")
 }
+
+func (t normalQueueTopology) messageStatusKey(partition int64, id string) string {
+	return strings.Join([]string{t.streamKey(partition), "status", id}, ":")
+}

--- a/internal/driver/bredis/partition_queue_common.go
+++ b/internal/driver/bredis/partition_queue_common.go
@@ -129,7 +129,7 @@ func (m partitionQueueMetadata) canonicalConfig() string {
 	return fmt.Sprintf("schema=%s;partitions=%d;capacity=%d", m.schema, m.partitions, m.capacity)
 }
 
-func ensurePartitionQueueMetadata(ctx context.Context, client redis.UniversalClient, key, queueName string, metadata partitionQueueMetadata) error {
+func ensurePartitionQueueMetadata(ctx context.Context, client redis.UniversalClient, wait replicationWait, key, queueName string, metadata partitionQueueMetadata) error {
 	want := metadata.canonicalConfig()
 	got, err := client.HGet(ctx, key, "canonical_config").Result()
 	if err == nil {
@@ -138,7 +138,14 @@ func ensurePartitionQueueMetadata(ctx context.Context, client redis.UniversalCli
 	if !errors.Is(err, redis.Nil) {
 		return fmt.Errorf("read %s metadata: %w", queueName, err)
 	}
-	if err := client.HSetNX(ctx, key, "canonical_config", want).Err(); err != nil {
+	if wait.enabled() {
+		_, err = wait.execute(ctx, client, key, func(pipe redis.Pipeliner) redis.Cmder {
+			return pipe.HSetNX(ctx, key, "canonical_config", want)
+		})
+	} else {
+		err = client.HSetNX(ctx, key, "canonical_config", want).Err()
+	}
+	if err != nil {
 		return fmt.Errorf("initialize %s metadata: %w", queueName, err)
 	}
 	got, err = client.HGet(ctx, key, "canonical_config").Result()
@@ -172,7 +179,16 @@ func bootstrapPartitionGroup(ctx context.Context, client redis.UniversalClient, 
 	return nil
 }
 
-func ackAndDelete(ctx context.Context, client redis.UniversalClient, stream, group string, ids ...string) error {
+func ackAndDelete(ctx context.Context, client redis.UniversalClient, wait replicationWait, stream, group string, ids ...string) error {
+	if wait.enabled() {
+		_, err := wait.executeMany(ctx, client, stream, func(pipe redis.Pipeliner) []redis.Cmder {
+			return []redis.Cmder{
+				pipe.XAck(ctx, stream, group, ids...),
+				pipe.XDel(ctx, stream, ids...),
+			}
+		})
+		return err
+	}
 	_, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		pipe.XAck(ctx, stream, group, ids...)
 		pipe.XDel(ctx, stream, ids...)

--- a/internal/driver/bredis/partition_queue_common.go
+++ b/internal/driver/bredis/partition_queue_common.go
@@ -18,7 +18,6 @@ import (
 const partitionQueueDefaultMaxLen int64 = 200000
 
 const (
-	partitionReaderCount     = 1
 	partitionReaderIdleDelay = 20 * time.Millisecond
 	partitionClaimInterval   = time.Second
 	partitionNonBlockingRead = -1 * time.Nanosecond

--- a/internal/driver/bredis/partition_reader_test.go
+++ b/internal/driver/bredis/partition_reader_test.go
@@ -6,9 +6,41 @@ import (
 	"time"
 )
 
-func TestPartitionReaderUsesFixedConcurrency(t *testing.T) {
-	if partitionReaderCount != 1 {
-		t.Fatalf("partitionReaderCount = %d, want 1", partitionReaderCount)
+func TestEffectivePartitionReaderCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		partitions int64
+		want       int
+	}{
+		{name: "configured", configured: 8, partitions: 1000, want: 8},
+		{name: "limited by partitions", configured: 8, partitions: 4, want: 4},
+		{name: "zero falls back", configured: 0, partitions: 1000, want: 1},
+		{name: "negative falls back", configured: -1, partitions: 1000, want: 1},
+		{name: "invalid partitions", configured: 8, partitions: 0, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectivePartitionReaderCount(tt.configured, tt.partitions); got != tt.want {
+				t.Fatalf("effectivePartitionReaderCount(%d, %d) = %d, want %d", tt.configured, tt.partitions, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartitionReaderAssignmentsCoverEachPartitionOnce(t *testing.T) {
+	const partitions = int64(1000)
+	const readers = 8
+	assignments := make([]int, partitions)
+	for readerID := range readers {
+		for partition := int64(readerID); partition < partitions; partition += readers {
+			assignments[partition]++
+		}
+	}
+	for partition, count := range assignments {
+		if count != 1 {
+			t.Fatalf("partition %d assigned %d times, want exactly once", partition, count)
+		}
 	}
 }
 

--- a/internal/driver/bredis/partition_runtime.go
+++ b/internal/driver/bredis/partition_runtime.go
@@ -18,6 +18,7 @@ type partitionRuntimeAdapter[T any] interface {
 	ConsumerPrefix() string
 	Partitions() int64
 	Workers() int
+	Readers() int
 	DispatchCapacity() int
 	EnsureMetadata(context.Context) error
 	BootstrapGroups(context.Context, string) error
@@ -69,10 +70,11 @@ func (r *partitionRuntime[T]) run(ctx context.Context, channel, topic string, ha
 	}
 	r.adapter.StartBackground(ctx, channel, topic)
 
+	readerCount := effectivePartitionReaderCount(r.adapter.Readers(), r.adapter.Partitions())
 	var readerWait sync.WaitGroup
-	for readerID := range partitionReaderCount {
+	for readerID := range readerCount {
 		readerID := readerID
-		readerWait.Go(func() { r.reader(ctx, channel, readerID, dispatch) })
+		readerWait.Go(func() { r.reader(ctx, channel, readerID, readerCount, dispatch) })
 	}
 
 	<-ctx.Done()
@@ -86,12 +88,25 @@ type partitionDispatch[T any] struct {
 	item     T
 }
 
-func (r *partitionRuntime[T]) reader(ctx context.Context, group string, readerID int, dispatch chan<- partitionDispatch[T]) {
+func effectivePartitionReaderCount(configured int, partitions int64) int {
+	if configured <= 0 {
+		configured = 1
+	}
+	if partitions <= 0 {
+		return 1
+	}
+	if int64(configured) > partitions {
+		return int(partitions)
+	}
+	return configured
+}
+
+func (r *partitionRuntime[T]) reader(ctx context.Context, group string, readerID, readerCount int, dispatch chan<- partitionDispatch[T]) {
 	consumer := fmt.Sprintf("%s-%s-r%d", r.adapter.ConsumerPrefix(), xidForRuntime(r.adapter), readerID)
 	states := make([]partitionReaderState, r.adapter.Partitions())
 	for ctx.Err() == nil {
 		active := false
-		for partition := int64(readerID); partition < r.adapter.Partitions(); partition += partitionReaderCount {
+		for partition := int64(readerID); partition < r.adapter.Partitions(); partition += int64(readerCount) {
 			partitionActive, ok := r.pollPartition(ctx, group, consumer, partition, &states[partition], dispatch)
 			if !ok {
 				return

--- a/internal/driver/bredis/partition_runtime_test.go
+++ b/internal/driver/bredis/partition_runtime_test.go
@@ -2,6 +2,7 @@ package bredis
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -21,11 +22,44 @@ type testPartitionRuntimeAdapter struct {
 	once           sync.Once
 }
 
+type isolatingPartitionRuntimeAdapter struct {
+	*testPartitionRuntimeAdapter
+	readerZeroStarted chan struct{}
+	readerZeroRelease chan struct{}
+	readOnce          sync.Once
+}
+
+func (a *isolatingPartitionRuntimeAdapter) Partitions() int64 { return 2 }
+func (a *isolatingPartitionRuntimeAdapter) Readers() int      { return 2 }
+func (a *isolatingPartitionRuntimeAdapter) Read(_ context.Context, _, _ string, partition int64) ([]int, error) {
+	if partition == 0 {
+		firstRead := false
+		a.readOnce.Do(func() {
+			firstRead = true
+			close(a.readerZeroStarted)
+		})
+		if firstRead {
+			return nil, errors.New("partition read failed")
+		}
+		<-a.readerZeroRelease
+		return nil, redis.Nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.readItems) == 0 {
+		return nil, redis.Nil
+	}
+	items := a.readItems
+	a.readItems = nil
+	return items, nil
+}
+
 func (a *testPartitionRuntimeAdapter) Name() string                                  { return "test queue" }
 func (a *testPartitionRuntimeAdapter) ConsumerPrefix() string                        { return "test" }
 func (a *testPartitionRuntimeAdapter) InstanceID() string                            { return "instance" }
 func (a *testPartitionRuntimeAdapter) Partitions() int64                             { return 1 }
 func (a *testPartitionRuntimeAdapter) Workers() int                                  { return 1 }
+func (a *testPartitionRuntimeAdapter) Readers() int                                  { return 1 }
 func (a *testPartitionRuntimeAdapter) DispatchCapacity() int                         { return 1 }
 func (a *testPartitionRuntimeAdapter) EnsureMetadata(context.Context) error          { return nil }
 func (a *testPartitionRuntimeAdapter) BootstrapGroups(context.Context, string) error { return nil }
@@ -116,6 +150,43 @@ func TestPartitionRuntimeCancellationDrainsWorkers(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("runtime did not stop after cancellation")
+	}
+}
+
+func TestPartitionRuntimeReaderIsolation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter := &isolatingPartitionRuntimeAdapter{
+		testPartitionRuntimeAdapter: &testPartitionRuntimeAdapter{
+			readItems:      []int{1},
+			processStarted: make(chan struct{}),
+		},
+		readerZeroStarted: make(chan struct{}),
+		readerZeroRelease: make(chan struct{}),
+	}
+	runtime := newPartitionRuntime[int](adapter)
+	done := make(chan struct{})
+	go func() {
+		runtime.run(ctx, "channel", "topic", nil)
+		close(done)
+	}()
+
+	select {
+	case <-adapter.readerZeroStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reader 0 did not start")
+	}
+	select {
+	case <-adapter.processStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reader 1 did not process while reader 0 was blocked")
+	}
+
+	cancel()
+	close(adapter.readerZeroRelease)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runtime did not stop after readers were released")
 	}
 }
 

--- a/internal/driver/bredis/processLog.go
+++ b/internal/driver/bredis/processLog.go
@@ -13,18 +13,30 @@ import (
 type ProcessLog struct {
 	client                  redis.UniversalClient
 	prefix                  string
+	normalQueuePartitions   int64
 	sequenceQueuePartitions int64
 }
 
 func NewProcessLog(client redis.UniversalClient, prefix string, sequenceQueuePartitions ...int64) *ProcessLog {
 	partitions := int64(0)
 	if len(sequenceQueuePartitions) > 0 {
-		partitions = normalizeSequenceQueuePartitionCount(sequenceQueuePartitions[0])
+		partitions = sequenceQueuePartitions[0]
+	}
+	return NewProcessLogWithPartitions(client, prefix, 0, partitions)
+}
+
+func NewProcessLogWithPartitions(client redis.UniversalClient, prefix string, normalQueuePartitions, sequenceQueuePartitions int64) *ProcessLog {
+	if normalQueuePartitions > 0 {
+		normalQueuePartitions = normalizePartitionCount(normalQueuePartitions)
+	}
+	if sequenceQueuePartitions > 0 {
+		sequenceQueuePartitions = normalizeSequenceQueuePartitionCount(sequenceQueuePartitions)
 	}
 	return &ProcessLog{
 		client:                  client,
 		prefix:                  prefix,
-		sequenceQueuePartitions: partitions,
+		normalQueuePartitions:   normalQueuePartitions,
+		sequenceQueuePartitions: sequenceQueuePartitions,
 	}
 }
 
@@ -38,23 +50,7 @@ func (t *ProcessLog) AddLog(ctx context.Context, data map[string]any) error {
 		moodType = btype.MoodType(cast.ToString(v))
 	}
 
-	if moodType == btype.SEQUENCE_QUEUE {
-
-		channel, id, topic, orderKey := "", "", "", ""
-		if v, ok := data["channel"]; ok {
-			channel = cast.ToString(v)
-		}
-		if v, ok := data["id"]; ok {
-			id = cast.ToString(v)
-		}
-		if v, ok := data["topic"]; ok {
-			topic = cast.ToString(v)
-		}
-		if v, ok := data["orderKey"]; ok {
-			orderKey = cast.ToString(v)
-		}
-
-		key := t.sequenceQueueStatusKey(channel, topic, orderKey, id)
+	if key := t.statusKey(data, moodType); key != "" {
 		if err := SaveHSetScript.Run(ctx, t.client, []string{key}, data).Err(); err != nil {
 			return err
 		}
@@ -74,6 +70,36 @@ func (t *ProcessLog) AddLog(ctx context.Context, data map[string]any) error {
 	}
 
 	return nil
+}
+
+func (t *ProcessLog) statusKey(data map[string]any, moodType btype.MoodType) string {
+	channel := cast.ToString(data["channel"])
+	topic := cast.ToString(data["topic"])
+	id := cast.ToString(data["id"])
+	if channel == "" || topic == "" || id == "" {
+		return ""
+	}
+
+	switch moodType {
+	case btype.NORMAL:
+		if t.normalQueuePartitions <= 0 {
+			return ""
+		}
+		topology := newNormalQueueTopology(t.prefix, channel, topic, t.normalQueuePartitions)
+		partition := topology.partition(id)
+		return topology.messageStatusKey(partition, id)
+	case btype.DELAY:
+		if t.normalQueuePartitions <= 0 {
+			return ""
+		}
+		topology := newDelayQueueTopology(t.prefix, channel, topic, t.normalQueuePartitions)
+		partition := topology.partition(id)
+		return topology.messageStatusKey(partition, id)
+	case btype.SEQUENCE_QUEUE:
+		return t.sequenceQueueStatusKey(channel, topic, cast.ToString(data["orderKey"]), id)
+	default:
+		return ""
+	}
 }
 
 func (t *ProcessLog) sequenceQueueStatusKey(channel, topic, orderKey, id string) string {

--- a/internal/driver/bredis/process_log_test.go
+++ b/internal/driver/bredis/process_log_test.go
@@ -1,0 +1,36 @@
+package bredis
+
+import (
+	"testing"
+
+	"github.com/retail-ai-inc/beanq/v4/internal/btype"
+)
+
+func TestProcessLogStatusKeyUsesMessageIDQueueTopology(t *testing.T) {
+	const (
+		prefix  = "prefix"
+		channel = "channel"
+		topic   = "topic"
+		id      = "message-01"
+	)
+	log := NewProcessLogWithPartitions(nil, prefix, 7, 11)
+	data := map[string]any{"channel": channel, "topic": topic, "id": id}
+
+	normalTopology := newNormalQueueTopology(prefix, channel, topic, 7)
+	partition := normalTopology.partition(id)
+	if got, want := log.statusKey(data, btype.NORMAL), normalTopology.messageStatusKey(partition, id); got != want {
+		t.Fatalf("normal status key = %q, want %q", got, want)
+	}
+
+	delayTopology := newDelayQueueTopology(prefix, channel, topic, 7)
+	if got, want := log.statusKey(data, btype.DELAY), delayTopology.messageStatusKey(partition, id); got != want {
+		t.Fatalf("delay status key = %q, want %q", got, want)
+	}
+}
+
+func TestProcessLogStatusKeyRequiresMessageID(t *testing.T) {
+	log := NewProcessLogWithPartitions(nil, "prefix", 7, 11)
+	if got := log.statusKey(map[string]any{"channel": "channel", "topic": "topic"}, btype.NORMAL); got != "" {
+		t.Fatalf("status key without id = %q, want empty", got)
+	}
+}

--- a/internal/driver/bredis/redisHolder.go
+++ b/internal/driver/bredis/redisHolder.go
@@ -3,9 +3,12 @@ package bredis
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -14,7 +17,9 @@ import (
 
 type RedisHolder struct {
 	redis.UniversalClient
-	mu                sync.RWMutex
+	caPool            atomic.Pointer[x509.CertPool]
+	closeOnce         sync.Once
+	closeErr          error
 	isCluster         bool
 	host              string
 	port              string
@@ -58,6 +63,11 @@ func NewRedisHolder(ctx context.Context, isCluster bool, host, port, username, p
 		caFile:            caFile,
 	}
 
+	if h.sslOn {
+		if err := h.Reload(ctx); err != nil {
+			return nil, err
+		}
+	}
 	client, err := h.newClient(ctx)
 	if err != nil {
 		return nil, err
@@ -67,97 +77,66 @@ func NewRedisHolder(ctx context.Context, isCluster bool, host, port, username, p
 	return h, nil
 }
 
-func (h *RedisHolder) Client() redis.UniversalClient {
-
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return h.UniversalClient
+func (h *RedisHolder) PipelinedForKey(ctx context.Context, key string, targetAddress string, asking bool, fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	if h.UniversalClient == nil {
+		return nil, fmt.Errorf("redis client is not initialized")
+	}
+	return pipelinedForClient(ctx, h.UniversalClient, key, targetAddress, asking, fn)
 }
 
 func (h *RedisHolder) Reload(ctx context.Context) error {
-
-	newClient, err := h.newClient(ctx)
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("reload Redis CA: %w", err)
+	}
+	tlsConfig, err := btls.LoadTLSConfigFromCA(h.caFile, h.verifyCertificate)
 	if err != nil {
-		return err
+		return fmt.Errorf("reload Redis CA: %w", err)
 	}
-	h.mu.Lock()
-	oldClient := h.UniversalClient
-	h.UniversalClient = newClient
-	h.mu.Unlock()
-	if oldClient != nil {
-		_ = oldClient.Close()
-	}
-
+	h.caPool.Store(tlsConfig.RootCAs)
 	return nil
 }
 
 func (h *RedisHolder) Close() error {
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	if h.UniversalClient == nil {
-		return nil
-	}
-
-	err := h.UniversalClient.Close()
-	h.UniversalClient = nil
-	return err
+	h.closeOnce.Do(func() {
+		if h.UniversalClient != nil {
+			h.closeErr = h.UniversalClient.Close()
+		}
+	})
+	return h.closeErr
 }
 
 func (h *RedisHolder) newClient(ctx context.Context) (redis.UniversalClient, error) {
 
 	var tlsConfig *tls.Config
 	if h.sslOn {
-		var err error
-		tlsConfig, err = btls.LoadTLSConfigFromCA(h.caFile, h.verifyCertificate)
-		if err != nil {
-			return nil, err
-		}
+		tlsConfig = h.tlsConfig()
 	}
 
-	hosts := strings.Split(h.host, ",")
-	for i, host := range hosts {
-		hs := strings.Split(host, ":")
-		if len(hs) == 1 {
-			hosts[i] = strings.Join([]string{host, h.port}, ":")
-		}
+	hosts, err := redisAddresses(h.host, h.port)
+	if err != nil {
+		return nil, err
+	}
+
+	options := &redis.UniversalOptions{
+		Addrs:        hosts,
+		Username:     h.username,
+		Password:     h.password,
+		DB:           h.db,
+		MaxRetries:   h.maxRetries,
+		DialTimeout:  h.dialTimeout,
+		ReadTimeout:  h.readTimeout,
+		WriteTimeout: h.writeTimeout,
+		PoolSize:     h.poolSize,
+		MinIdleConns: h.minIdleConns,
+		PoolTimeout:  h.poolTimeout,
+		TLSConfig:    tlsConfig,
 	}
 
 	var client redis.UniversalClient
 	if h.isCluster {
-		client = redis.NewClusterClient(&redis.ClusterOptions{
-			Addrs:          hosts,
-			Username:       h.username,
-			Password:       h.password,
-			MaxRetries:     h.maxRetries,
-			DialTimeout:    h.dialTimeout,
-			ReadTimeout:    h.readTimeout,
-			WriteTimeout:   h.writeTimeout,
-			PoolSize:       h.poolSize,
-			MinIdleConns:   h.minIdleConns,
-			PoolTimeout:    h.poolTimeout,
-			RouteByLatency: true,
-
-			TLSConfig: tlsConfig,
-		})
+		client = redis.NewClusterClient(options.Cluster())
 	} else {
-		client = redis.NewUniversalClient(&redis.UniversalOptions{
-			Addrs:          hosts,
-			Username:       h.username,
-			Password:       h.password,
-			DB:             h.db,
-			MaxRetries:     h.maxRetries,
-			DialTimeout:    h.dialTimeout,
-			ReadTimeout:    h.readTimeout,
-			WriteTimeout:   h.writeTimeout,
-			PoolSize:       h.poolSize,
-			MinIdleConns:   h.minIdleConns,
-			PoolTimeout:    h.poolTimeout,
-			RouteByLatency: true,
-
-			TLSConfig: tlsConfig,
-		})
+		client = redis.NewUniversalClient(options)
 	}
 
 	if err := client.Ping(ctx).Err(); err != nil {
@@ -166,4 +145,63 @@ func (h *RedisHolder) newClient(ctx context.Context) (redis.UniversalClient, err
 	}
 
 	return client, nil
+}
+
+func redisAddresses(hosts, defaultPort string) ([]string, error) {
+	defaultPort = strings.TrimPrefix(strings.TrimSpace(defaultPort), ":")
+	addresses := strings.Split(hosts, ",")
+	result := make([]string, 0, len(addresses))
+
+	for _, address := range addresses {
+		address = strings.TrimSpace(address)
+		if address == "" {
+			return nil, fmt.Errorf("redis host contains an empty address")
+		}
+
+		if host, port, err := net.SplitHostPort(address); err == nil {
+			result = append(result, net.JoinHostPort(host, port))
+			continue
+		}
+
+		host := strings.TrimSuffix(strings.TrimPrefix(address, "["), "]")
+		if strings.Contains(address, ":") && net.ParseIP(host) == nil {
+			return nil, fmt.Errorf("invalid redis address %q", address)
+		}
+		if defaultPort == "" {
+			return nil, fmt.Errorf("redis address %q does not include a port", address)
+		}
+		result = append(result, net.JoinHostPort(host, defaultPort))
+	}
+
+	return result, nil
+}
+
+func (h *RedisHolder) tlsConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, // Verification uses the atomically reloadable CA pool below.
+		VerifyConnection: func(state tls.ConnectionState) error {
+			if !h.verifyCertificate {
+				return nil
+			}
+			if len(state.PeerCertificates) == 0 {
+				return fmt.Errorf("verify Redis TLS connection: peer sent no certificates")
+			}
+
+			intermediates := x509.NewCertPool()
+			for _, certificate := range state.PeerCertificates[1:] {
+				intermediates.AddCert(certificate)
+			}
+			_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+				DNSName:       state.ServerName,
+				Roots:         h.caPool.Load(),
+				Intermediates: intermediates,
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			})
+			if err != nil {
+				return fmt.Errorf("verify Redis TLS connection: %w", err)
+			}
+			return nil
+		},
+	}
 }

--- a/internal/driver/bredis/redisHolder.go
+++ b/internal/driver/bredis/redisHolder.go
@@ -20,6 +20,7 @@ type RedisHolder struct {
 	caPool            atomic.Pointer[x509.CertPool]
 	closeOnce         sync.Once
 	closeErr          error
+	watcherCancel     context.CancelFunc
 	isCluster         bool
 	host              string
 	port              string
@@ -44,23 +45,32 @@ func NewRedisHolder(ctx context.Context, isCluster bool, host, port, username, p
 	minIdleConns int,
 	sslOn bool, caFile string, verifyCertificate bool) (*RedisHolder, error) {
 
+	return NewRedisHolderWithOptions(ctx, RedisClientOptions{
+		IsCluster: isCluster, Host: host, Port: port, Username: username, Password: password,
+		Database: db, MaxRetries: maxRetries, DialTimeout: dialTimeout, ReadTimeout: readTimeout,
+		WriteTimeout: writeTimeout, PoolTimeout: poolTimeout, PoolSize: poolSize, MinIdleConnections: minIdleConns,
+		TLS: RedisTLSOptions{On: sslOn, CAFile: caFile, VerifyCertificate: verifyCertificate},
+	})
+}
+
+func NewRedisHolderWithOptions(ctx context.Context, options RedisClientOptions) (*RedisHolder, error) {
 	h := &RedisHolder{
-		isCluster:         isCluster,
-		host:              host,
-		port:              port,
-		username:          username,
-		password:          password,
-		db:                db,
-		maxRetries:        maxRetries,
-		dialTimeout:       dialTimeout,
-		readTimeout:       readTimeout,
-		writeTimeout:      writeTimeout,
-		poolTimeout:       poolTimeout,
-		poolSize:          poolSize,
-		minIdleConns:      minIdleConns,
-		sslOn:             sslOn,
-		verifyCertificate: verifyCertificate,
-		caFile:            caFile,
+		isCluster:         options.IsCluster,
+		host:              options.Host,
+		port:              options.Port,
+		username:          options.Username,
+		password:          options.Password,
+		db:                options.Database,
+		maxRetries:        options.MaxRetries,
+		dialTimeout:       options.DialTimeout,
+		readTimeout:       options.ReadTimeout,
+		writeTimeout:      options.WriteTimeout,
+		poolTimeout:       options.PoolTimeout,
+		poolSize:          options.PoolSize,
+		minIdleConns:      options.MinIdleConnections,
+		sslOn:             options.TLS.On,
+		verifyCertificate: options.TLS.VerifyCertificate,
+		caFile:            options.TLS.CAFile,
 	}
 
 	if h.sslOn {
@@ -104,6 +114,9 @@ func (h *RedisHolder) Reload(ctx context.Context) error {
 
 func (h *RedisHolder) Close() error {
 	h.closeOnce.Do(func() {
+		if h.watcherCancel != nil {
+			h.watcherCancel()
+		}
 		if h.UniversalClient != nil {
 			h.closeErr = h.UniversalClient.Close()
 		}

--- a/internal/driver/bredis/redisHolder.go
+++ b/internal/driver/bredis/redisHolder.go
@@ -77,6 +77,12 @@ func NewRedisHolder(ctx context.Context, isCluster bool, host, port, username, p
 	return h, nil
 }
 
+// Client exposes the current underlying client to packages that need to
+// distinguish standalone and Cluster Redis clients.
+func (h *RedisHolder) Client() redis.UniversalClient {
+	return h.UniversalClient
+}
+
 func (h *RedisHolder) PipelinedForKey(ctx context.Context, key string, targetAddress string, asking bool, fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
 	if h.UniversalClient == nil {
 		return nil, fmt.Errorf("redis client is not initialized")

--- a/internal/driver/bredis/redisHolder_test.go
+++ b/internal/driver/bredis/redisHolder_test.go
@@ -1,0 +1,230 @@
+package bredis
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestRedisHolderReloadCA(t *testing.T) {
+	caOne, leafOne := testCertificateChain(t, 1)
+	caTwo, leafTwo := testCertificateChain(t, 2)
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caFile, caOne, 0600); err != nil {
+		t.Fatalf("write first CA: %v", err)
+	}
+
+	client := &closeCountingClient{}
+	holder := &RedisHolder{UniversalClient: client, caFile: caFile, verifyCertificate: true}
+	if err := holder.Reload(context.Background()); err != nil {
+		t.Fatalf("reload first CA: %v", err)
+	}
+	config := holder.tlsConfig()
+	verifyTLSState(t, config, leafOne, true)
+	verifyTLSState(t, config, leafTwo, false)
+
+	if err := os.WriteFile(caFile, caTwo, 0600); err != nil {
+		t.Fatalf("write second CA: %v", err)
+	}
+	if err := holder.Reload(context.Background()); err != nil {
+		t.Fatalf("reload second CA: %v", err)
+	}
+	if holder.UniversalClient != client {
+		t.Fatal("Reload replaced the Redis client")
+	}
+	verifyTLSState(t, config, leafOne, false)
+	verifyTLSState(t, config, leafTwo, true)
+
+	if err := os.WriteFile(caFile, []byte("invalid CA"), 0600); err != nil {
+		t.Fatalf("write invalid CA: %v", err)
+	}
+	if err := holder.Reload(context.Background()); err == nil {
+		t.Fatal("Reload accepted an invalid CA")
+	}
+	verifyTLSState(t, config, leafTwo, true)
+}
+
+func TestRedisHolderReloadHonorsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	holder := &RedisHolder{caFile: filepath.Join(t.TempDir(), "missing.pem")}
+	if err := holder.Reload(ctx); err == nil {
+		t.Fatal("Reload accepted a canceled context")
+	}
+}
+
+func TestRedisHolderTLSConfigSkipsVerificationWhenDisabled(t *testing.T) {
+	holder := &RedisHolder{verifyCertificate: false}
+	if err := holder.tlsConfig().VerifyConnection(tls.ConnectionState{}); err != nil {
+		t.Fatalf("VerifyConnection returned error: %v", err)
+	}
+}
+
+func TestRedisHolderConcurrentCAReload(t *testing.T) {
+	_, leafOne := testCertificateChain(t, 11)
+	_, leafTwo := testCertificateChain(t, 12)
+	poolOne := x509.NewCertPool()
+	poolOne.AddCert(leafOne)
+	poolTwo := x509.NewCertPool()
+	poolTwo.AddCert(leafTwo)
+
+	holder := &RedisHolder{verifyCertificate: true}
+	holder.caPool.Store(poolOne)
+	config := holder.tlsConfig()
+	state := tls.ConnectionState{PeerCertificates: []*x509.Certificate{leafOne}, ServerName: "redis.test"}
+
+	var wait sync.WaitGroup
+	for range 8 {
+		wait.Go(func() {
+			for range 1000 {
+				_ = config.VerifyConnection(state)
+			}
+		})
+	}
+	for range 1000 {
+		holder.caPool.Store(poolTwo)
+		holder.caPool.Store(poolOne)
+	}
+	wait.Wait()
+}
+
+func TestRedisAddresses(t *testing.T) {
+	tests := []struct {
+		name        string
+		hosts       string
+		defaultPort string
+		want        []string
+		wantErr     bool
+	}{
+		{name: "hostname with default port", hosts: "redis", defaultPort: "6379", want: []string{"redis:6379"}},
+		{name: "preserve explicit port", hosts: "redis:6380", defaultPort: "6379", want: []string{"redis:6380"}},
+		{name: "trim multiple hosts", hosts: " redis-1 , redis-2:6380 ", defaultPort: "6379", want: []string{"redis-1:6379", "redis-2:6380"}},
+		{name: "IPv6 with default port", hosts: "2001:db8::1", defaultPort: "6379", want: []string{"[2001:db8::1]:6379"}},
+		{name: "bracketed IPv6 with port", hosts: "[2001:db8::1]:6380", defaultPort: "6379", want: []string{"[2001:db8::1]:6380"}},
+		{name: "empty host", hosts: "", defaultPort: "6379", wantErr: true},
+		{name: "empty host entry", hosts: "redis-1,,redis-2", defaultPort: "6379", wantErr: true},
+		{name: "missing port", hosts: "redis", wantErr: true},
+		{name: "invalid address", hosts: "redis:bad:address", defaultPort: "6379", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := redisAddresses(tt.hosts, tt.defaultPort)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("redisAddresses() = %v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("redisAddresses() error = %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("redisAddresses() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("redisAddresses()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRedisHolderCloseOnce(t *testing.T) {
+	client := &closeCountingClient{}
+	holder := &RedisHolder{UniversalClient: client}
+
+	if err := holder.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := holder.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if got := client.closes.Load(); got != 1 {
+		t.Fatalf("underlying Close calls = %d, want 1", got)
+	}
+}
+
+type closeCountingClient struct {
+	redis.UniversalClient
+	closes atomic.Int32
+}
+
+func (c *closeCountingClient) Close() error {
+	c.closes.Add(1)
+	return nil
+}
+
+func verifyTLSState(t *testing.T, config *tls.Config, certificate *x509.Certificate, wantValid bool) {
+	t.Helper()
+	err := config.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{certificate},
+		ServerName:       "redis.test",
+	})
+	if (err == nil) != wantValid {
+		t.Fatalf("VerifyConnection() error = %v, want valid = %v", err, wantValid)
+	}
+}
+
+func testCertificateChain(t *testing.T, serial int64) ([]byte, *x509.Certificate) {
+	t.Helper()
+	now := time.Now()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: "BeanQ test CA"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	ca, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(serial + 100),
+		Subject:      pkix.Name{CommonName: "redis.test"},
+		DNSNames:     []string{"redis.test"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, ca, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf certificate: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("parse leaf certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), leaf
+}

--- a/internal/driver/bredis/redisHolder_test.go
+++ b/internal/driver/bredis/redisHolder_test.go
@@ -159,6 +159,19 @@ func TestRedisHolderCloseOnce(t *testing.T) {
 	}
 }
 
+func TestRedisHolderCloseStopsWatcher(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	holder := &RedisHolder{watcherCancel: cancel}
+	if err := holder.Close(); err != nil {
+		t.Fatalf(`Close error: %v`, err)
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal(`Close did not stop TLS watcher`)
+	}
+}
+
 func TestRedisHolderClientReturnsUnderlyingClient(t *testing.T) {
 	underlying := &closeCountingClient{}
 	holder := &RedisHolder{UniversalClient: underlying}

--- a/internal/driver/bredis/redisHolder_test.go
+++ b/internal/driver/bredis/redisHolder_test.go
@@ -159,6 +159,15 @@ func TestRedisHolderCloseOnce(t *testing.T) {
 	}
 }
 
+func TestRedisHolderClientReturnsUnderlyingClient(t *testing.T) {
+	underlying := &closeCountingClient{}
+	holder := &RedisHolder{UniversalClient: underlying}
+
+	if got := holder.Client(); got != underlying {
+		t.Fatalf("Client() = %T, want original underlying client", got)
+	}
+}
+
 type closeCountingClient struct {
 	redis.UniversalClient
 	closes atomic.Int32

--- a/internal/driver/bredis/replication.go
+++ b/internal/driver/bredis/replication.go
@@ -1,0 +1,240 @@
+package bredis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	ErrAmbiguousCommit = errors.New("redis write commit is ambiguous")
+	ErrClusterRouting  = errors.New("redis cluster routing failed")
+)
+
+type ReplicationNotConfirmedError struct {
+	Required     int
+	Acknowledged int64
+	Timeout      time.Duration
+	Cause        error
+}
+
+func (e *ReplicationNotConfirmedError) Error() string {
+	message := fmt.Sprintf("redis WAIT acknowledged by %d replicas, want %d within %s", e.Acknowledged, e.Required, e.Timeout)
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", message, e.Cause)
+	}
+	return message
+}
+
+func (e *ReplicationNotConfirmedError) Unwrap() []error {
+	errList := []error{ErrAmbiguousCommit}
+	if e.Cause != nil {
+		errList = append(errList, e.Cause)
+	}
+	return errList
+}
+
+type ClusterRoutingError struct {
+	Key   string
+	Cause error
+}
+
+func (e *ClusterRoutingError) Error() string {
+	return fmt.Sprintf("redis cluster routing failed for key %q: %v", e.Key, e.Cause)
+}
+
+func (e *ClusterRoutingError) Unwrap() []error {
+	return []error{ErrClusterRouting, e.Cause}
+}
+
+type replicationWait struct {
+	replicas int
+	timeout  time.Duration
+}
+
+type keyedPipeliner interface {
+	PipelinedForKey(context.Context, string, string, bool, func(redis.Pipeliner) error) ([]redis.Cmder, error)
+}
+
+type redisDoer interface {
+	Do(context.Context, ...any) *redis.Cmd
+}
+
+func firstReplicationWait(waits []replicationWait) replicationWait {
+	if len(waits) == 0 {
+		return replicationWait{}
+	}
+	return waits[0]
+}
+
+func (w replicationWait) enabled() bool {
+	return w.replicas > 0
+}
+
+func (w replicationWait) execute(ctx context.Context, client redis.UniversalClient, key string, write func(redis.Pipeliner) redis.Cmder) (redis.Cmder, error) {
+	commands, err := w.executeMany(ctx, client, key, func(pipe redis.Pipeliner) []redis.Cmder {
+		return []redis.Cmder{write(pipe)}
+	})
+	if len(commands) == 0 {
+		return nil, err
+	}
+	return commands[0], err
+}
+
+func (w replicationWait) executeMany(ctx context.Context, client redis.UniversalClient, key string, write func(redis.Pipeliner) []redis.Cmder) ([]redis.Cmder, error) {
+	var writeCmds []redis.Cmder
+	var waitCmd *redis.Cmd
+	run := func(targetAddress string, asking bool) error {
+		writeCmds = nil
+		waitCmd = nil
+		_, err := pipelineForKey(ctx, client, key, targetAddress, asking, func(pipe redis.Pipeliner) error {
+			writeCmds = write(pipe)
+			waitCmd = pipe.Do(ctx, "WAIT", w.replicas, waitTimeoutMilliseconds(w.timeout))
+			return nil
+		})
+		return err
+	}
+
+	err := run("", false)
+	redirectCmd := firstRedirect(writeCmds)
+	if kind, address, ok := clusterRedirect(redirectCmd); ok {
+		switch kind {
+		case "MOVED":
+			if cluster := clusterClient(client); cluster != nil {
+				cluster.ReloadState(ctx)
+			}
+			err = run(address, false)
+		case "ASK":
+			err = run(address, true)
+		}
+	}
+	if redirectCmd = firstRedirect(writeCmds); redirectCmd != nil {
+		return nil, &ClusterRoutingError{Key: key, Cause: redirectCmd.Err()}
+	}
+	if len(writeCmds) == 0 {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("redis write commands were not queued")
+	}
+	for _, cmd := range writeCmds {
+		if cmd == nil || cmd.Err() == nil {
+			continue
+		}
+		writeErr := cmd.Err()
+		if _, ok := errors.AsType[redis.Error](writeErr); ok {
+			return nil, writeErr
+		}
+		return nil, &ReplicationNotConfirmedError{Required: w.replicas, Timeout: w.timeout, Cause: writeErr}
+	}
+	if waitCmd == nil {
+		return nil, errors.New("redis WAIT command was not queued")
+	}
+	if waitErr := w.waitResult(waitCmd); waitErr != nil {
+		return nil, waitErr
+	}
+	if err != nil {
+		return nil, &ReplicationNotConfirmedError{Required: w.replicas, Timeout: w.timeout, Cause: err}
+	}
+	return writeCmds, nil
+}
+
+func (w replicationWait) confirm(ctx context.Context, client redisDoer) error {
+	return w.waitResult(client.Do(ctx, "WAIT", w.replicas, waitTimeoutMilliseconds(w.timeout)))
+}
+
+func (w replicationWait) waitResult(waitCmd *redis.Cmd) error {
+	value, err := waitCmd.Result()
+	if err != nil {
+		return &ReplicationNotConfirmedError{Required: w.replicas, Timeout: w.timeout, Cause: err}
+	}
+	acknowledged, ok := value.(int64)
+	if !ok {
+		return &ReplicationNotConfirmedError{Required: w.replicas, Timeout: w.timeout, Cause: fmt.Errorf("redis WAIT returned %T, want integer", value)}
+	}
+	if acknowledged < int64(w.replicas) {
+		return &ReplicationNotConfirmedError{Required: w.replicas, Acknowledged: acknowledged, Timeout: w.timeout}
+	}
+	return nil
+}
+
+func firstRedirect(commands []redis.Cmder) redis.Cmder {
+	for _, command := range commands {
+		if _, _, ok := clusterRedirect(command); ok {
+			return command
+		}
+	}
+	return nil
+}
+
+func waitTimeoutMilliseconds(timeout time.Duration) int64 {
+	if timeout > 0 && timeout < time.Millisecond {
+		return 1
+	}
+	return timeout.Milliseconds()
+}
+
+func pipelineForKey(ctx context.Context, client redis.UniversalClient, key, targetAddress string, asking bool, fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	if keyed, ok := client.(keyedPipeliner); ok {
+		return keyed.PipelinedForKey(ctx, key, targetAddress, asking, fn)
+	}
+	return pipelinedForClient(ctx, client, key, targetAddress, asking, fn)
+}
+
+func pipelinedForClient(ctx context.Context, client redis.UniversalClient, key, targetAddress string, asking bool, fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	var node *redis.Client
+	switch client := client.(type) {
+	case *redis.Client:
+		node = client
+	case *redis.ClusterClient:
+		var err error
+		node, err = client.MasterForKey(ctx, key)
+		if err != nil {
+			return nil, &ClusterRoutingError{Key: key, Cause: err}
+		}
+	default:
+		return nil, fmt.Errorf("redis client %T does not support keyed pipelines", client)
+	}
+
+	target := node
+	if targetAddress != "" {
+		options := *node.Options()
+		options.Addr = targetAddress
+		options.MaxRetries = -1
+		target = redis.NewClient(&options)
+		defer target.Close()
+	}
+
+	conn := target.Conn()
+	defer conn.Close()
+	return conn.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		if asking {
+			pipe.Do(ctx, "ASKING")
+		}
+		return fn(pipe)
+	})
+}
+
+func clusterClient(client redis.UniversalClient) *redis.ClusterClient {
+	if holder, ok := client.(*RedisHolder); ok {
+		client = holder.UniversalClient
+	}
+	cluster, _ := client.(*redis.ClusterClient)
+	return cluster
+}
+
+func clusterRedirect(cmd redis.Cmder) (kind, address string, ok bool) {
+	if cmd == nil {
+		return "", "", false
+	}
+	if address, ok := redis.IsMovedError(cmd.Err()); ok {
+		return "MOVED", address, true
+	}
+	if address, ok := redis.IsAskError(cmd.Err()); ok {
+		return "ASK", address, true
+	}
+	return "", "", false
+}

--- a/internal/driver/bredis/replication_test.go
+++ b/internal/driver/bredis/replication_test.go
@@ -1,0 +1,272 @@
+package bredis
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type recordedRedisCommand struct {
+	connection int
+	name       string
+}
+
+type waitTestServer struct {
+	listener net.Listener
+	waitAcks int64
+	mu       sync.Mutex
+	commands []recordedRedisCommand
+}
+
+func newWaitTestServer(t *testing.T, waitAcks int64) *waitTestServer {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &waitTestServer{listener: listener, waitAcks: waitAcks}
+	t.Cleanup(func() { _ = listener.Close() })
+	go server.serve()
+	return server
+}
+
+func (s *waitTestServer) serve() {
+	connection := 0
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		connection++
+		go s.serveConn(conn, connection)
+	}
+}
+
+func (s *waitTestServer) serveConn(conn net.Conn, connection int) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	for {
+		args, err := readRESPCommand(reader)
+		if err != nil {
+			return
+		}
+		name := strings.ToUpper(args[0])
+		s.mu.Lock()
+		s.commands = append(s.commands, recordedRedisCommand{connection: connection, name: name})
+		s.mu.Unlock()
+		switch name {
+		case "HELLO":
+			_, _ = writer.WriteString("-ERR unknown command 'hello'\r\n")
+		case "XADD":
+			_, _ = writer.WriteString("$3\r\n1-0\r\n")
+		case "WAIT":
+			_, _ = fmt.Fprintf(writer, ":%d\r\n", s.waitAcks)
+		case "EVAL":
+			_, _ = writer.WriteString("*3\r\n$9\r\nSCHEDULED\r\n$3\r\n1-0\r\n$1\r\n1\r\n")
+		case "INFO":
+			info := "# Replication\r\nrole:master\r\nconnected_slaves:0\r\n"
+			_, _ = fmt.Fprintf(writer, "$%d\r\n%s\r\n", len(info), info)
+		case "XACK", "XDEL", "HSETNX":
+			_, _ = writer.WriteString(":1\r\n")
+		default:
+			_, _ = writer.WriteString("+OK\r\n")
+		}
+		_ = writer.Flush()
+	}
+}
+
+func readRESPCommand(reader *bufio.Reader) ([]string, error) {
+	header, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if len(header) == 0 || header[0] != '*' {
+		return nil, fmt.Errorf("unexpected RESP header %q", header)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(header[1:]))
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, count)
+	for range count {
+		lengthLine, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		length, err := strconv.Atoi(strings.TrimSpace(lengthLine[1:]))
+		if err != nil {
+			return nil, err
+		}
+		value := make([]byte, length+2)
+		if _, err := io.ReadFull(reader, value); err != nil {
+			return nil, err
+		}
+		args = append(args, string(value[:length]))
+	}
+	return args, nil
+}
+
+func (s *waitTestServer) client() *redis.Client {
+	return redis.NewClient(&redis.Options{Addr: s.listener.Addr().String(), Protocol: 2, DisableIdentity: true})
+}
+
+func (s *waitTestServer) snapshot() []recordedRedisCommand {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordedRedisCommand(nil), s.commands...)
+}
+
+func TestReplicationWaitUsesSameConnection(t *testing.T) {
+	server := newWaitTestServer(t, 1)
+	client := server.client()
+	defer client.Close()
+	wait := replicationWait{replicas: 1, timeout: time.Second}
+	_, err := wait.execute(context.Background(), client, "queue:{slot}:stream", func(pipe redis.Pipeliner) redis.Cmder {
+		return pipe.XAdd(context.Background(), &redis.XAddArgs{Stream: "queue:{slot}:stream", Values: map[string]any{"id": "1"}})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := server.snapshot()
+	for index := range commands[:len(commands)-1] {
+		if commands[index].name == "XADD" && commands[index+1].name == "WAIT" {
+			if commands[index].connection != commands[index+1].connection {
+				t.Fatal("XADD and WAIT used different connections")
+			}
+			return
+		}
+	}
+	t.Fatalf("XADD followed by WAIT not found in %#v", commands)
+}
+
+func TestReplicationWaitReusesPooledConnection(t *testing.T) {
+	server := newWaitTestServer(t, 1)
+	client := server.client()
+	defer client.Close()
+	wait := replicationWait{replicas: 1, timeout: time.Second}
+	for range 2 {
+		_, err := wait.execute(context.Background(), client, "queue:{slot}:stream", func(pipe redis.Pipeliner) redis.Cmder {
+			return pipe.XAdd(context.Background(), &redis.XAddArgs{Stream: "queue:{slot}:stream", Values: map[string]any{"id": "1"}})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	var connections []int
+	for _, command := range server.snapshot() {
+		if command.name == "XADD" {
+			connections = append(connections, command.connection)
+		}
+	}
+	if len(connections) != 2 || connections[0] != connections[1] {
+		t.Fatalf("expected pooled connection reuse, got %v", connections)
+	}
+}
+
+func TestAckAndDeleteWaitOrder(t *testing.T) {
+	server := newWaitTestServer(t, 1)
+	client := server.client()
+	defer client.Close()
+	wait := replicationWait{replicas: 1, timeout: time.Second}
+	if err := ackAndDelete(context.Background(), client, wait, "queue:{slot}:stream", "workers", "1-0"); err != nil {
+		t.Fatal(err)
+	}
+	commands := server.snapshot()
+	for i := 0; i+2 < len(commands); i++ {
+		if commands[i].name == "XACK" && commands[i+1].name == "XDEL" && commands[i+2].name == "WAIT" {
+			if commands[i].connection != commands[i+1].connection || commands[i].connection != commands[i+2].connection {
+				t.Fatalf("commands used different connections: %#v", commands[i:i+3])
+			}
+			return
+		}
+	}
+	t.Fatalf("XACK/XDEL/WAIT order not found in %#v", commands)
+}
+
+func TestValidateReplicationTopologyRejectsStandaloneWithoutReplicas(t *testing.T) {
+	server := newWaitTestServer(t, 0)
+	client := server.client()
+	defer client.Close()
+	err := ValidateReplicationTopology(context.Background(), client, 1)
+	if err == nil {
+		t.Fatal("expected insufficient replica error")
+	}
+	if !strings.Contains(err.Error(), client.Options().Addr) ||
+		!strings.Contains(err.Error(), "required 1, actual 0") {
+		t.Fatalf("unexpected topology error: %v", err)
+	}
+}
+
+func TestReplicationWaitInsufficientAcknowledgementsIsAmbiguous(t *testing.T) {
+	server := newWaitTestServer(t, 0)
+	client := server.client()
+	defer client.Close()
+	wait := replicationWait{replicas: 1, timeout: 25 * time.Millisecond}
+	_, err := wait.execute(context.Background(), client, "queue:{slot}:stream", func(pipe redis.Pipeliner) redis.Cmder {
+		return pipe.XAdd(context.Background(), &redis.XAddArgs{Stream: "queue:{slot}:stream", Values: map[string]any{"id": "1"}})
+	})
+	if !errors.Is(err, ErrAmbiguousCommit) {
+		t.Fatalf("expected ambiguous commit, got %v", err)
+	}
+	replicationErr, ok := errors.AsType[*ReplicationNotConfirmedError](err)
+	if !ok || replicationErr.Acknowledged != 0 || replicationErr.Required != 1 {
+		t.Fatalf("unexpected replication error: %#v", replicationErr)
+	}
+}
+
+func TestSequenceQueueWaitUsesEvalOnFreshNode(t *testing.T) {
+	server := newWaitTestServer(t, 1)
+	client := server.client()
+	defer client.Close()
+	topology := newSequenceQueueTopology("p", "c", "t", 1)
+	store := newSequenceQueueStore(client, topology, 10, time.Second)
+	result, err := store.enqueueWithWait(context.Background(), "order-1", map[string]any{"id": "message-1"}, replicationWait{replicas: 1, timeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Code != "SCHEDULED" || result.SchedulerID != "1-0" || result.Pending != 1 {
+		t.Fatalf("unexpected enqueue result: %#v", result)
+	}
+	commands := server.snapshot()
+	for index := range commands[:len(commands)-1] {
+		if commands[index].name == "EVAL" && commands[index+1].name == "WAIT" {
+			return
+		}
+	}
+	t.Fatalf("EVAL followed by WAIT not found in %#v", commands)
+}
+
+func TestWaitTimeoutMillisecondsRoundsUp(t *testing.T) {
+	if waitTimeoutMilliseconds(500*time.Microsecond) != 1 {
+		t.Fail()
+	}
+}
+
+func TestClusterRedirect(t *testing.T) {
+	for _, test := range []struct {
+		err     string
+		kind    string
+		address string
+	}{
+		{err: "MOVED 1234 127.0.0.1:7001", kind: "MOVED", address: "127.0.0.1:7001"},
+		{err: "ASK 4321 127.0.0.1:7002", kind: "ASK", address: "127.0.0.1:7002"},
+	} {
+		cmd := redis.NewCmd(context.Background())
+		cmd.SetErr(errors.New(test.err))
+		kind, address, ok := clusterRedirect(cmd)
+		if !ok || kind != test.kind || address != test.address {
+			t.Fatalf("clusterRedirect(%q) = %q, %q, %v", test.err, kind, address, ok)
+		}
+	}
+}

--- a/internal/driver/bredis/replication_topology.go
+++ b/internal/driver/bredis/replication_topology.go
@@ -1,0 +1,80 @@
+package bredis
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// ValidateReplicationTopology verifies that every writable Redis node has enough
+// online replicas for the configured WAIT requirement.
+func ValidateReplicationTopology(ctx context.Context, client redis.UniversalClient, requiredReplicas int) error {
+	if requiredReplicas <= 0 {
+		return nil
+	}
+	switch client := client.(type) {
+	case *redis.Client:
+		return validateMasterReplication(ctx, client, requiredReplicas)
+	case *redis.ClusterClient:
+		return client.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+			return validateMasterReplication(ctx, master, requiredReplicas)
+		})
+	default:
+		return fmt.Errorf("validate redis replication topology: unsupported client %T", client)
+	}
+}
+
+func validateMasterReplication(ctx context.Context, master *redis.Client, requiredReplicas int) error {
+	info, err := master.Info(ctx, "replication").Result()
+	if err != nil {
+		return fmt.Errorf("inspect redis replication at %s: %w", master.Options().Addr, err)
+	}
+	role, online, err := parseReplicationInfo(info)
+	if err != nil {
+		return fmt.Errorf("inspect redis replication at %s: %w", master.Options().Addr, err)
+	}
+	if role != "master" {
+		return fmt.Errorf("redis node %s is %s, want master", master.Options().Addr, role)
+	}
+	if online < requiredReplicas {
+		return fmt.Errorf("redis master %s has insufficient online replicas: required %d, actual %d", master.Options().Addr, requiredReplicas, online)
+	}
+	return nil
+}
+
+func parseReplicationInfo(info string) (string, int, error) {
+	role := ""
+	online := 0
+	connected := -1
+	replicaEntries := 0
+	for _, rawLine := range strings.Split(info, "\n") {
+		line := strings.TrimSpace(rawLine)
+		switch {
+		case strings.HasPrefix(line, "role:"):
+			role = strings.TrimSpace(strings.TrimPrefix(line, "role:"))
+		case strings.HasPrefix(line, "connected_slaves:"):
+			value := strings.TrimSpace(strings.TrimPrefix(line, "connected_slaves:"))
+			count, err := strconv.Atoi(value)
+			if err != nil {
+				return "", 0, fmt.Errorf("invalid connected_slaves %q: %w", value, err)
+			}
+			connected = count
+		case strings.HasPrefix(line, "slave"), strings.HasPrefix(line, "replica"):
+			replicaEntries++
+			if strings.Contains(line, "state=online") {
+				online++
+			}
+		}
+	}
+	if role == "" {
+		return "", 0, fmt.Errorf("replication INFO does not contain role")
+	}
+	// Older Redis-compatible servers may expose only connected_slaves.
+	if replicaEntries == 0 && connected > 0 {
+		online = connected
+	}
+	return role, online, nil
+}

--- a/internal/driver/bredis/replication_topology_test.go
+++ b/internal/driver/bredis/replication_topology_test.go
@@ -1,0 +1,40 @@
+package bredis
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidateReplicationTopologyDisabledDoesNotUseClient(t *testing.T) {
+	if err := ValidateReplicationTopology(context.Background(), nil, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseReplicationInfoCountsOnlyOnlineReplicas(t *testing.T) {
+	info := strings.Join([]string{
+		"# Replication",
+		"role:master",
+		"connected_slaves:2",
+		"slave0:ip=127.0.0.1,port=6380,state=online,offset=1,lag=0",
+		"slave1:ip=127.0.0.1,port=6381,state=offline,offset=1,lag=0",
+	}, "\r\n")
+	role, online, err := parseReplicationInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role != "master" || online != 1 {
+		t.Fatalf("got role=%q online=%d", role, online)
+	}
+}
+
+func TestParseReplicationInfoSupportsConnectedSlavesOnly(t *testing.T) {
+	role, online, err := parseReplicationInfo("role:master\nconnected_slaves:2\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if role != "master" || online != 2 {
+		t.Fatalf("got role=%q online=%d", role, online)
+	}
+}

--- a/internal/driver/bredis/schedule.go
+++ b/internal/driver/bredis/schedule.go
@@ -27,10 +27,11 @@ func newScheduleWithPartitions(client redis.UniversalClient, prefix string, maxL
 
 func newScheduleWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *Schedule {
 	partitions = normalizePartitionCount(partitions)
+	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
+		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
+	base.processLogger = NewProcessLogWithPartitions(client, prefix, partitions, 0)
 	return &Schedule{
-		maxLen: maxLen, partitions: partitions, wait: wait,
-		base: newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-			deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait}),
+		maxLen: maxLen, partitions: partitions, wait: wait, base: base,
 	}
 }
 

--- a/internal/driver/bredis/schedule.go
+++ b/internal/driver/bredis/schedule.go
@@ -14,6 +14,7 @@ type Schedule struct {
 	base       queueBase
 	maxLen     int64
 	partitions int64
+	wait       replicationWait
 }
 
 func NewSchedule(client redis.UniversalClient, prefix string, consumerCount int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Schedule {
@@ -21,16 +22,20 @@ func NewSchedule(client redis.UniversalClient, prefix string, consumerCount int6
 }
 
 func newScheduleWithPartitions(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Schedule {
+	return newScheduleWithPartitionsAndWait(client, prefix, maxLen, partitions, consumerPoolSize, deadLetterIdle, config, replicationWait{})
+}
+
+func newScheduleWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *Schedule {
 	partitions = normalizePartitionCount(partitions)
 	return &Schedule{
-		maxLen: maxLen, partitions: partitions,
+		maxLen: maxLen, partitions: partitions, wait: wait,
 		base: newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-			deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config}),
+			deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait}),
 	}
 }
 
 func (s *Schedule) store(channel, topic string) *delayQueueStore {
-	return newDelayQueueStore(s.base.client, newDelayQueueTopology(s.base.prefix, channel, topic, s.partitions), s.maxLen)
+	return newDelayQueueStore(s.base.client, newDelayQueueTopology(s.base.prefix, channel, topic, s.partitions), s.maxLen, s.wait)
 }
 
 func (s *Schedule) Publish(ctx context.Context, data map[string]any) error {
@@ -38,7 +43,7 @@ func (s *Schedule) Publish(ctx context.Context, data map[string]any) error {
 	if err := store.ensureMetadata(ctx); err != nil {
 		return err
 	}
-	return store.enqueue(ctx, data)
+	return store.enqueue(ctx, data, s.wait)
 }
 
 func (s *Schedule) Consume(ctx context.Context, channel, topic string, handler public.CallbackWithRetry) {

--- a/internal/driver/bredis/schedule.go
+++ b/internal/driver/bredis/schedule.go
@@ -22,16 +22,16 @@ func NewSchedule(client redis.UniversalClient, prefix string, consumerCount int6
 }
 
 func newScheduleWithPartitions(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Schedule {
-	return newScheduleWithPartitionsAndWait(client, prefix, maxLen, partitions, consumerPoolSize, deadLetterIdle, config, replicationWait{})
+	return newScheduleWithOptions(queueOptions{client: client, prefix: prefix, maxLen: maxLen, partitions: partitions,
+		runtime: queueRuntimeOptions{workers: consumerPoolSize}, deadLetterIdle: deadLetterIdle, captureConfig: config})
 }
 
-func newScheduleWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *Schedule {
-	partitions = normalizePartitionCount(partitions)
-	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
-	base.processLogger = NewProcessLogWithPartitions(client, prefix, partitions, 0)
+func newScheduleWithOptions(options queueOptions) *Schedule {
+	options.partitions = normalizePartitionCount(options.partitions)
+	base := newQueueBase(options)
+	base.processLogger = NewProcessLogWithPartitions(options.client, options.prefix, options.partitions, 0)
 	return &Schedule{
-		maxLen: maxLen, partitions: partitions, wait: wait, base: base,
+		maxLen: options.maxLen, partitions: options.partitions, wait: options.wait, base: base,
 	}
 }
 

--- a/internal/driver/bredis/sequenceQueue.go
+++ b/internal/driver/bredis/sequenceQueue.go
@@ -19,6 +19,7 @@ type SequenceQueue struct {
 	base       queueBase
 	maxLen     int64
 	partitions int64
+	wait       replicationWait
 }
 
 func NewSequenceQueue(client redis.UniversalClient, prefix string, maxLen int64, consumerCount int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *SequenceQueue {
@@ -26,13 +27,18 @@ func NewSequenceQueue(client redis.UniversalClient, prefix string, maxLen int64,
 }
 
 func newSequenceQueueWithPartitions(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *SequenceQueue {
+	return newSequenceQueueWithPartitionsAndWait(client, prefix, maxLen, partitions, consumerPoolSize, deadLetterIdle, config, replicationWait{})
+}
+
+func newSequenceQueueWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *SequenceQueue {
 	partitions = normalizeSequenceQueuePartitionCount(partitions)
 	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config})
+		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
 	base.processLogger = NewProcessLog(client, prefix, partitions)
 	return &SequenceQueue{
 		maxLen:     maxLen,
 		partitions: partitions,
+		wait:       wait,
 		base:       base,
 	}
 }
@@ -46,7 +52,7 @@ func (q *SequenceQueue) PublishNewSequence(ctx context.Context, data map[string]
 	if err := store.ensureMetadata(ctx); err != nil {
 		return err
 	}
-	result, err := store.enqueue(ctx, orderKey, data)
+	result, err := store.enqueueWithWait(ctx, orderKey, data, q.wait)
 	if err != nil {
 		return err
 	}
@@ -71,7 +77,7 @@ func (q *SequenceQueue) ConsumerSequence(ctx context.Context, channel, topic str
 
 func (q *SequenceQueue) sequenceQueueStore(channel, topic string, maxLen int64) *sequenceQueueStore {
 	topology := newSequenceQueueTopology(q.base.prefix, channel, topic, q.partitions)
-	return newSequenceQueueStore(q.base.client, topology, maxLen, q.base.deadLetterIdle)
+	return newSequenceQueueStore(q.base.client, topology, maxLen, q.base.deadLetterIdle, q.wait)
 }
 
 func sequenceQueueFailedData(channel, topic, orderKey, raw string, cause error) map[string]any {

--- a/internal/driver/bredis/sequenceQueue.go
+++ b/internal/driver/bredis/sequenceQueue.go
@@ -27,18 +27,18 @@ func NewSequenceQueue(client redis.UniversalClient, prefix string, maxLen int64,
 }
 
 func newSequenceQueueWithPartitions(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *SequenceQueue {
-	return newSequenceQueueWithPartitionsAndWait(client, prefix, maxLen, partitions, consumerPoolSize, deadLetterIdle, config, replicationWait{})
+	return newSequenceQueueWithOptions(queueOptions{client: client, prefix: prefix, maxLen: maxLen, partitions: partitions,
+		runtime: queueRuntimeOptions{workers: consumerPoolSize}, deadLetterIdle: deadLetterIdle, captureConfig: config})
 }
 
-func newSequenceQueueWithPartitionsAndWait(client redis.UniversalClient, prefix string, maxLen, partitions int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config, wait replicationWait) *SequenceQueue {
-	partitions = normalizeSequenceQueuePartitionCount(partitions)
-	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
-		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
-	base.processLogger = NewProcessLogWithPartitions(client, prefix, 0, partitions)
+func newSequenceQueueWithOptions(options queueOptions) *SequenceQueue {
+	options.partitions = normalizeSequenceQueuePartitionCount(options.partitions)
+	base := newQueueBase(options)
+	base.processLogger = NewProcessLogWithPartitions(options.client, options.prefix, 0, options.partitions)
 	return &SequenceQueue{
-		maxLen:     maxLen,
-		partitions: partitions,
-		wait:       wait,
+		maxLen:     options.maxLen,
+		partitions: options.partitions,
+		wait:       options.wait,
 		base:       base,
 	}
 }

--- a/internal/driver/bredis/sequenceQueue.go
+++ b/internal/driver/bredis/sequenceQueue.go
@@ -34,7 +34,7 @@ func newSequenceQueueWithPartitionsAndWait(client redis.UniversalClient, prefix 
 	partitions = normalizeSequenceQueuePartitionCount(partitions)
 	base := newQueueBase(queueBaseOptions{client: client, prefix: prefix,
 		deadLetterIdle: deadLetterIdle, consumerPoolSize: consumerPoolSize, captureConfig: config, wait: wait})
-	base.processLogger = NewProcessLog(client, prefix, partitions)
+	base.processLogger = NewProcessLogWithPartitions(client, prefix, 0, partitions)
 	return &SequenceQueue{
 		maxLen:     maxLen,
 		partitions: partitions,

--- a/internal/driver/bredis/sequenceQueue.go
+++ b/internal/driver/bredis/sequenceQueue.go
@@ -68,7 +68,7 @@ func (q *SequenceQueue) PublishNewSequence(ctx context.Context, data map[string]
 
 func (q *SequenceQueue) ConsumerSequence(ctx context.Context, channel, topic string, do public.CallbackWithRetry) {
 	store := q.sequenceQueueStore(channel, topic, q.maxLen)
-	runtime := newSequenceQueueRuntime(store, q.base.processLogger, q.base.consumerPoolSize,
+	runtime := newSequenceQueueRuntime(store, q.base.processLogger, q.base.consumerPoolSize, q.base.consumerReaderPoolSize,
 		func(ctx context.Context, channel, topic, raw string, handler public.CallbackWithRetry) (map[string]any, error) {
 			return executeSequenceQueueMessage(ctx, channel, topic, raw, handler, q.base.captureConfig)
 		})

--- a/internal/driver/bredis/sequence_queue_integration_test.go
+++ b/internal/driver/bredis/sequence_queue_integration_test.go
@@ -17,7 +17,51 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/retail-ai-inc/beanq/v4/helper/bstatus"
+	"github.com/retail-ai-inc/beanq/v4/internal/btype"
 )
+
+func TestNormalAndDelayStatusRedisIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, configuredPrefix := newSequenceQueueIntegrationClient(t, ctx)
+	t.Cleanup(func() { _ = client.Close() })
+
+	prefix := fmt.Sprintf("%sstatus_it_%d", configuredPrefix, time.Now().UnixNano())
+	t.Cleanup(func() {
+		cleanupRedisKeysWithPrefix(t, context.Background(), client, prefix)
+	})
+	const partitions = int64(7)
+	processLog := NewProcessLogWithPartitions(client, prefix, partitions, 11)
+	status := NewStatusWithPartitions(client, prefix, partitions, 11)
+
+	for _, tt := range []struct {
+		name     string
+		moodType btype.MoodType
+	}{
+		{name: "normal", moodType: btype.NORMAL},
+		{name: "delay", moodType: btype.DELAY},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			channel := tt.name + "-channel"
+			topic := "status-topic"
+			id := tt.name + "-message-01"
+			data := map[string]any{
+				"channel": channel, "topic": topic, "id": id,
+				"moodType": tt.moodType, "status": bstatus.StatusSuccess,
+			}
+			if err := processLog.AddLog(ctx, data); err != nil {
+				t.Fatalf("AddLog: %v", err)
+			}
+			got, err := status.Status(ctx, channel, topic, id)
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if got["id"] != id || got["status"] != bstatus.StatusSuccess {
+				t.Fatalf("status = %#v, want id %q and success", got, id)
+			}
+		})
+	}
+}
 
 type sequenceQueueIntegrationConfig struct {
 	Redis struct {
@@ -402,6 +446,28 @@ func cleanupSequenceQueueIntegrationKeys(t *testing.T, ctx context.Context, clie
 	var cursor uint64
 	for {
 		keys, next, err := client.Scan(ctx, cursor, "*:"+prefix+":*", 100).Result()
+		if err != nil {
+			t.Errorf("scan integration keys: %v", err)
+			return
+		}
+		if len(keys) > 0 {
+			if err := client.Del(ctx, keys...).Err(); err != nil {
+				t.Errorf("delete integration keys: %v", err)
+				return
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			return
+		}
+	}
+}
+
+func cleanupRedisKeysWithPrefix(t *testing.T, ctx context.Context, client redis.UniversalClient, prefix string) {
+	t.Helper()
+	var cursor uint64
+	for {
+		keys, next, err := client.Scan(ctx, cursor, prefix+"*", 100).Result()
 		if err != nil {
 			t.Errorf("scan integration keys: %v", err)
 			return

--- a/internal/driver/bredis/sequence_queue_runtime.go
+++ b/internal/driver/bredis/sequence_queue_runtime.go
@@ -35,6 +35,7 @@ type sequenceQueueRuntime struct {
 	logger     processLogger
 	execute    sequenceQueueExecutor
 	workers    int
+	readers    int
 	partitions int64
 	lease      time.Duration
 	instanceID string
@@ -54,7 +55,7 @@ const (
 	sequenceQueueStoreFatal
 )
 
-func newSequenceQueueRuntime(store *sequenceQueueStore, processLogger processLogger, workers int, execute sequenceQueueExecutor) *sequenceQueueRuntime {
+func newSequenceQueueRuntime(store *sequenceQueueStore, processLogger processLogger, workers, readers int, execute sequenceQueueExecutor) *sequenceQueueRuntime {
 	if workers <= 0 {
 		workers = 1
 	}
@@ -63,6 +64,7 @@ func newSequenceQueueRuntime(store *sequenceQueueStore, processLogger processLog
 		logger:     processLogger,
 		execute:    execute,
 		workers:    workers,
+		readers:    readers,
 		partitions: store.topology.partitions,
 		lease:      store.lease,
 		instanceID: xid.New().String(),
@@ -83,6 +85,7 @@ func (a *sequenceQueueRuntimeAdapter) ConsumerPrefix() string { return "sequence
 func (a *sequenceQueueRuntimeAdapter) InstanceID() string     { return a.runtime.instanceID }
 func (a *sequenceQueueRuntimeAdapter) Partitions() int64      { return a.runtime.partitions }
 func (a *sequenceQueueRuntimeAdapter) Workers() int           { return a.runtime.workers }
+func (a *sequenceQueueRuntimeAdapter) Readers() int           { return a.runtime.readers }
 func (a *sequenceQueueRuntimeAdapter) DispatchCapacity() int  { return a.runtime.workers }
 func (a *sequenceQueueRuntimeAdapter) EnsureMetadata(ctx context.Context) error {
 	return a.runtime.store.ensureMetadata(ctx)

--- a/internal/driver/bredis/sequence_queue_store.go
+++ b/internal/driver/bredis/sequence_queue_store.go
@@ -21,9 +21,10 @@ const (
 type sequenceQueueStore struct {
 	client   redis.UniversalClient
 	scripts  *ScriptCatalog
+	lease    time.Duration
 	topology sequenceQueueTopology
 	maxLen   int64
-	lease    time.Duration
+	wait     replicationWait
 }
 
 type sequenceQueueToken struct {
@@ -62,14 +63,14 @@ type sequenceQueueAutoClaimResult struct {
 	Cursor string
 }
 
-func newSequenceQueueStore(client redis.UniversalClient, topology sequenceQueueTopology, maxLen int64, lease time.Duration) *sequenceQueueStore {
+func newSequenceQueueStore(client redis.UniversalClient, topology sequenceQueueTopology, maxLen int64, lease time.Duration, waits ...replicationWait) *sequenceQueueStore {
 	if maxLen <= 0 {
 		maxLen = sequenceQueueDefaultMaxLen
 	}
 	if lease <= 0 {
 		lease = time.Minute
 	}
-	return &sequenceQueueStore{client: client, scripts: DefaultScriptCatalog(), topology: topology, maxLen: maxLen, lease: lease}
+	return &sequenceQueueStore{client: client, scripts: DefaultScriptCatalog(), topology: topology, maxLen: maxLen, lease: lease, wait: firstReplicationWait(waits)}
 }
 
 func (s *sequenceQueueStore) canonicalConfig() string {
@@ -82,7 +83,7 @@ func (s *sequenceQueueStore) metadata() partitionQueueMetadata {
 
 // ensureMetadata elects the first complete queue configuration as canonical.
 func (s *sequenceQueueStore) ensureMetadata(ctx context.Context) error {
-	return ensurePartitionQueueMetadata(ctx, s.client, s.topology.metadataKey(), "sequence queue", s.metadata())
+	return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "sequence queue", s.metadata())
 }
 
 func (s *sequenceQueueStore) bootstrapGroups(ctx context.Context, group string) error {
@@ -90,6 +91,10 @@ func (s *sequenceQueueStore) bootstrapGroups(ctx context.Context, group string) 
 }
 
 func (s *sequenceQueueStore) enqueue(ctx context.Context, orderKey string, data map[string]any) (sequenceQueueEnqueueResult, error) {
+	return s.enqueueWithWait(ctx, orderKey, data, replicationWait{})
+}
+
+func (s *sequenceQueueStore) enqueueWithWait(ctx context.Context, orderKey string, data map[string]any, wait replicationWait) (sequenceQueueEnqueueResult, error) {
 	if orderKey == "" {
 		return sequenceQueueEnqueueResult{}, errors.New("missing orderKey")
 	}
@@ -98,12 +103,33 @@ func (s *sequenceQueueStore) enqueue(ctx context.Context, orderKey string, data 
 		return sequenceQueueEnqueueResult{}, fmt.Errorf("marshal sequence queue message: %w", err)
 	}
 	partition := s.topology.partition(orderKey)
-	values, err := s.runTriplet(ctx, ScriptSequenceQueueEnqueue, []string{
+	keys := []string{
 		s.topology.orderListKey(partition, orderKey), s.topology.orderStateKey(partition, orderKey),
 		s.topology.schedulerKey(partition), s.topology.partitionStateKey(partition), s.topology.isolationKey(partition),
-	}, string(payload), orderKey, s.maxLen)
+	}
+	if !wait.enabled() {
+		values, err := s.runTriplet(ctx, ScriptSequenceQueueEnqueue, keys, string(payload), orderKey, s.maxLen)
+		if err != nil {
+			return sequenceQueueEnqueueResult{}, fmt.Errorf("enqueue sequence queue message: %w", err)
+		}
+		return sequenceQueueEnqueueResult{Code: values[0], SchedulerID: values[1], Pending: cast.ToInt64(values[2])}, nil
+	}
+	routingKey := s.topology.schedulerKey(partition)
+	var resultCmd *redis.Cmd
+	_, err = wait.execute(ctx, s.client, routingKey, func(pipe redis.Pipeliner) redis.Cmder {
+		resultCmd = pipe.Eval(ctx, sequenceQueueEnqueueLua, keys, string(payload), orderKey, s.maxLen)
+		return resultCmd
+	})
 	if err != nil {
 		return sequenceQueueEnqueueResult{}, fmt.Errorf("enqueue sequence queue message: %w", err)
+	}
+	raw, err := resultCmd.Result()
+	if err != nil {
+		return sequenceQueueEnqueueResult{}, fmt.Errorf("enqueue sequence queue message: %w", err)
+	}
+	values, err := strictTriplet(ScriptSequenceQueueEnqueue, raw)
+	if err != nil {
+		return sequenceQueueEnqueueResult{}, err
 	}
 	return sequenceQueueEnqueueResult{Code: values[0], SchedulerID: values[1], Pending: cast.ToInt64(values[2])}, nil
 }
@@ -154,7 +180,7 @@ func (s *sequenceQueueStore) autoClaim(ctx context.Context, group, consumer stri
 }
 
 func (s *sequenceQueueStore) discardSchedulerToken(ctx context.Context, stream, group, id string) error {
-	return ackAndDelete(ctx, s.client, stream, group, id)
+	return ackAndDelete(ctx, s.client, s.wait, stream, group, id)
 }
 
 func tokenFromMessage(partition int64, message redis.XMessage) (*sequenceQueueToken, error) {
@@ -220,11 +246,47 @@ func (s *sequenceQueueStore) validateToken(token sequenceQueueToken) error {
 }
 
 func (s *sequenceQueueStore) runTriplet(ctx context.Context, script string, keys []string, args ...any) ([3]string, error) {
-	var result [3]string
+	if s.wait.enabled() {
+		source, err := sequenceQueueScriptSource(script)
+		if err != nil {
+			return [3]string{}, err
+		}
+		var resultCmd *redis.Cmd
+		_, err = s.wait.execute(ctx, s.client, keys[0], func(pipe redis.Pipeliner) redis.Cmder {
+			resultCmd = pipe.Eval(ctx, source, keys, args...)
+			return resultCmd
+		})
+		if err != nil {
+			return [3]string{}, err
+		}
+		value, err := resultCmd.Result()
+		if err != nil {
+			return [3]string{}, err
+		}
+		return strictTriplet(script, value)
+	}
 	value, err := s.scripts.Run(ctx, s.client, script, keys, args...)
 	if err != nil {
-		return result, err
+		return [3]string{}, err
 	}
+	return strictTriplet(script, value)
+}
+
+func sequenceQueueScriptSource(name string) (string, error) {
+	switch name {
+	case ScriptSequenceQueueEnqueue:
+		return sequenceQueueEnqueueLua, nil
+	case ScriptSequenceQueueLease:
+		return sequenceQueueLeaseLua, nil
+	case ScriptSequenceQueueFinalize:
+		return sequenceQueueFinalizeLua, nil
+	default:
+		return "", fmt.Errorf("redis script %q is not registered for replication WAIT", name)
+	}
+}
+
+func strictTriplet(script string, value any) ([3]string, error) {
+	var result [3]string
 	raw, ok := value.([]interface{})
 	if !ok || len(raw) != 3 {
 		return result, fmt.Errorf("script %s returned malformed result %#v; want strict triplet", script, value)

--- a/internal/driver/bredis/sequence_queue_store.go
+++ b/internal/driver/bredis/sequence_queue_store.go
@@ -90,6 +90,9 @@ func (s *sequenceQueueStore) bootstrapGroups(ctx context.Context, group string) 
 	return bootstrapPartitionGroups(ctx, s.client, group, "sequence queue", s.topology.partitions, s.topology.schedulerKey)
 }
 
+// enqueue for test
+//
+//nolint:unused
 func (s *sequenceQueueStore) enqueue(ctx context.Context, orderKey string, data map[string]any) (sequenceQueueEnqueueResult, error) {
 	return s.enqueueWithWait(ctx, orderKey, data, replicationWait{})
 }

--- a/internal/driver/bredis/status.go
+++ b/internal/driver/bredis/status.go
@@ -11,24 +11,44 @@ import (
 type Status struct {
 	client                  redis.UniversalClient
 	prefix                  string
+	normalQueuePartitions   int64
 	sequenceQueuePartitions int64
 }
 
 func NewStatus(client redis.UniversalClient, prefix string, sequenceQueuePartitions ...int64) *Status {
 	partitions := int64(0)
 	if len(sequenceQueuePartitions) > 0 {
-		partitions = normalizeSequenceQueuePartitionCount(sequenceQueuePartitions[0])
+		partitions = sequenceQueuePartitions[0]
+	}
+	return NewStatusWithPartitions(client, prefix, 0, partitions)
+}
+
+func NewStatusWithPartitions(client redis.UniversalClient, prefix string, normalQueuePartitions, sequenceQueuePartitions int64) *Status {
+	if normalQueuePartitions > 0 {
+		normalQueuePartitions = normalizePartitionCount(normalQueuePartitions)
+	}
+	if sequenceQueuePartitions > 0 {
+		sequenceQueuePartitions = normalizeSequenceQueuePartitionCount(sequenceQueuePartitions)
 	}
 	return &Status{
 		client:                  client,
 		prefix:                  prefix,
-		sequenceQueuePartitions: partitions,
+		normalQueuePartitions:   normalQueuePartitions,
+		sequenceQueuePartitions: sequenceQueuePartitions,
 	}
 }
 
 func (t *Status) Status(ctx context.Context, channel, topic, id string) (map[string]string, error) {
-	key := tool.MakeStatusKey(t.prefix, channel, topic, id)
-	return t.waitStatus(ctx, key)
+	if t.normalQueuePartitions <= 0 || id == "" {
+		return t.waitStatus(ctx, tool.MakeStatusKey(t.prefix, channel, topic, id))
+	}
+	normalTopology := newNormalQueueTopology(t.prefix, channel, topic, t.normalQueuePartitions)
+	delayTopology := newDelayQueueTopology(t.prefix, channel, topic, t.normalQueuePartitions)
+	partition := normalTopology.partition(id)
+	return t.waitStatuses(ctx,
+		normalTopology.messageStatusKey(partition, id),
+		delayTopology.messageStatusKey(partition, id),
+	)
 }
 
 func (t *Status) SequenceStatus(ctx context.Context, channel, topic, orderKey, id string) (map[string]string, error) {
@@ -41,30 +61,29 @@ func (t *Status) SequenceStatus(ctx context.Context, channel, topic, orderKey, i
 }
 
 func (t *Status) waitStatus(ctx context.Context, key string) (map[string]string, error) {
+	return t.waitStatuses(ctx, key)
+}
+
+func (t *Status) waitStatuses(ctx context.Context, keys ...string) (map[string]string, error) {
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
-
-			cmd := t.client.HGetAll(ctx, key)
-
-			if err := cmd.Err(); err != nil {
-				return nil, err
-			}
-
-			val := cmd.Val()
-			if len(val) <= 0 {
-				continue
-			}
-
-			if v, ok := val["status"]; ok {
-				if v != bstatus.StatusSuccess && v != bstatus.StatusFailed {
+			for _, key := range keys {
+				cmd := t.client.HGetAll(ctx, key)
+				if err := cmd.Err(); err != nil {
+					return nil, err
+				}
+				val := cmd.Val()
+				if len(val) <= 0 {
 					continue
 				}
+				if v, ok := val["status"]; ok && v != bstatus.StatusSuccess && v != bstatus.StatusFailed {
+					continue
+				}
+				return val, nil
 			}
-
-			return val, nil
 		}
 	}
 }

--- a/internal/driver/bredis/stream_consumer.go
+++ b/internal/driver/bredis/stream_consumer.go
@@ -7,39 +7,46 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/retail-ai-inc/beanq/v4/internal/boptions"
 	"github.com/retail-ai-inc/beanq/v4/internal/capture"
 )
 
 type BlockDuration func() time.Duration
 
 type queueBaseOptions struct {
-	client           redis.UniversalClient
-	prefix           string
-	consumerPoolSize int
-	deadLetterIdle   time.Duration
-	captureConfig    *capture.Config
-	wait             replicationWait
+	client                 redis.UniversalClient
+	prefix                 string
+	consumerPoolSize       int
+	consumerReaderPoolSize int
+	deadLetterIdle         time.Duration
+	captureConfig          *capture.Config
+	wait                   replicationWait
 }
 
 type queueBase struct {
-	client           redis.UniversalClient
-	processLogger    processLogger
-	prefix           string
-	consumerPoolSize int
-	deadLetterIdle   time.Duration
-	captureConfig    *capture.Config
-	wait             replicationWait
+	client                 redis.UniversalClient
+	processLogger          processLogger
+	prefix                 string
+	consumerPoolSize       int
+	consumerReaderPoolSize int
+	deadLetterIdle         time.Duration
+	captureConfig          *capture.Config
+	wait                   replicationWait
 }
 
 func newQueueBase(options queueBaseOptions) queueBase {
+	if options.consumerReaderPoolSize == 0 {
+		options.consumerReaderPoolSize = boptions.DefaultOptions.ConsumerReaderPoolSize
+	}
 	return queueBase{
-		client:           options.client,
-		processLogger:    NewProcessLog(options.client, options.prefix),
-		prefix:           options.prefix,
-		consumerPoolSize: options.consumerPoolSize,
-		deadLetterIdle:   options.deadLetterIdle,
-		captureConfig:    options.captureConfig,
-		wait:             options.wait,
+		client:                 options.client,
+		processLogger:          NewProcessLog(options.client, options.prefix),
+		prefix:                 options.prefix,
+		consumerPoolSize:       options.consumerPoolSize,
+		consumerReaderPoolSize: options.consumerReaderPoolSize,
+		deadLetterIdle:         options.deadLetterIdle,
+		captureConfig:          options.captureConfig,
+		wait:                   options.wait,
 	}
 }
 

--- a/internal/driver/bredis/stream_consumer.go
+++ b/internal/driver/bredis/stream_consumer.go
@@ -18,6 +18,7 @@ type queueBaseOptions struct {
 	consumerPoolSize int
 	deadLetterIdle   time.Duration
 	captureConfig    *capture.Config
+	wait             replicationWait
 }
 
 type queueBase struct {
@@ -27,6 +28,7 @@ type queueBase struct {
 	consumerPoolSize int
 	deadLetterIdle   time.Duration
 	captureConfig    *capture.Config
+	wait             replicationWait
 }
 
 func newQueueBase(options queueBaseOptions) queueBase {
@@ -37,6 +39,7 @@ func newQueueBase(options queueBaseOptions) queueBase {
 		consumerPoolSize: options.consumerPoolSize,
 		deadLetterIdle:   options.deadLetterIdle,
 		captureConfig:    options.captureConfig,
+		wait:             options.wait,
 	}
 }
 

--- a/internal/driver/bredis/stream_consumer.go
+++ b/internal/driver/bredis/stream_consumer.go
@@ -13,14 +13,20 @@ import (
 
 type BlockDuration func() time.Duration
 
-type queueBaseOptions struct {
-	client                 redis.UniversalClient
-	prefix                 string
-	consumerPoolSize       int
-	consumerReaderPoolSize int
-	deadLetterIdle         time.Duration
-	captureConfig          *capture.Config
-	wait                   replicationWait
+type queueRuntimeOptions struct {
+	workers int
+	readers int
+}
+
+type queueOptions struct {
+	client         redis.UniversalClient
+	prefix         string
+	maxLen         int64
+	partitions     int64
+	runtime        queueRuntimeOptions
+	deadLetterIdle time.Duration
+	captureConfig  *capture.Config
+	wait           replicationWait
 }
 
 type queueBase struct {
@@ -34,16 +40,16 @@ type queueBase struct {
 	wait                   replicationWait
 }
 
-func newQueueBase(options queueBaseOptions) queueBase {
-	if options.consumerReaderPoolSize == 0 {
-		options.consumerReaderPoolSize = boptions.DefaultOptions.ConsumerReaderPoolSize
+func newQueueBase(options queueOptions) queueBase {
+	if options.runtime.readers == 0 {
+		options.runtime.readers = boptions.DefaultOptions.ConsumerReaderPoolSize
 	}
 	return queueBase{
 		client:                 options.client,
 		processLogger:          NewProcessLog(options.client, options.prefix),
 		prefix:                 options.prefix,
-		consumerPoolSize:       options.consumerPoolSize,
-		consumerReaderPoolSize: options.consumerReaderPoolSize,
+		consumerPoolSize:       options.runtime.workers,
+		consumerReaderPoolSize: options.runtime.readers,
 		deadLetterIdle:         options.deadLetterIdle,
 		captureConfig:          options.captureConfig,
 		wait:                   options.wait,

--- a/internal/driver/bredis/stream_queue_runtime.go
+++ b/internal/driver/bredis/stream_queue_runtime.go
@@ -88,7 +88,7 @@ func (a *streamQueueAdapter) Process(ctx context.Context, _, _, group, _ string,
 		logger.New().Error(err)
 		return
 	}
-	if err := ackAndDelete(ctx, a.client, item.stream, group, item.message.ID); err != nil {
+	if err := ackAndDelete(ctx, a.client, a.base.wait, item.stream, group, item.message.ID); err != nil {
 		logger.New().Error(err)
 	}
 }

--- a/internal/driver/bredis/stream_queue_runtime.go
+++ b/internal/driver/bredis/stream_queue_runtime.go
@@ -35,6 +35,7 @@ func (a *streamQueueAdapter) ConsumerPrefix() string                   { return 
 func (a *streamQueueAdapter) InstanceID() string                       { return a.instanceID }
 func (a *streamQueueAdapter) Partitions() int64                        { return a.partitions }
 func (a *streamQueueAdapter) Workers() int                             { return a.base.consumerPoolSize }
+func (a *streamQueueAdapter) Readers() int                             { return a.base.consumerReaderPoolSize }
 func (a *streamQueueAdapter) DispatchCapacity() int                    { return max(1, a.Workers()) * 2 }
 func (a *streamQueueAdapter) EnsureMetadata(ctx context.Context) error { return a.ensureMetadata(ctx) }
 func (a *streamQueueAdapter) BootstrapGroups(ctx context.Context, group string) error {

--- a/internal/driver/btls/tls.go
+++ b/internal/driver/btls/tls.go
@@ -29,7 +29,7 @@ func LoadTLSConfigFromCA(caFile string, verifyCertificate bool) (*tls.Config, er
 	return &tls.Config{
 		RootCAs:            pool,
 		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: verifyCertificate, // Preserve existing Redis verifyCertificate behavior.
+		InsecureSkipVerify: !verifyCertificate,
 	}, nil
 }
 

--- a/internal/driver/btls/tls_test.go
+++ b/internal/driver/btls/tls_test.go
@@ -33,8 +33,8 @@ func TestLoadTLSConfigFromCA(t *testing.T) {
 	if cfg.MinVersion != tls.VersionTLS12 {
 		t.Fatalf("MinVersion = %v, want %v", cfg.MinVersion, tls.VersionTLS12)
 	}
-	if !cfg.InsecureSkipVerify {
-		t.Fatal("InsecureSkipVerify should preserve verifyCertificate=true behavior")
+	if cfg.InsecureSkipVerify {
+		t.Fatal("InsecureSkipVerify should be false when verifyCertificate=true")
 	}
 }
 

--- a/internal/routers/middleware.go
+++ b/internal/routers/middleware.go
@@ -37,7 +37,7 @@ func HeaderRule() Middleware {
 	return func(next HandleFunc) HandleFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
-			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;")
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 			next(w, r)

--- a/internal/routers/middleware_test.go
+++ b/internal/routers/middleware_test.go
@@ -19,6 +19,20 @@ type deadlineRecorder struct {
 	called   bool
 }
 
+func TestHeaderRuleAllowsBootstrapDataImages(t *testing.T) {
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	HeaderRule()(func(http.ResponseWriter, *http.Request) {})(res, req)
+
+	policy := res.Header().Get("Content-Security-Policy")
+	if !strings.Contains(policy, "img-src 'self' data:;") {
+		t.Fatalf("CSP does not allow Bootstrap data images: %q", policy)
+	}
+	if strings.Contains(policy, "script-src 'self' data:") {
+		t.Fatalf("CSP unexpectedly allows data scripts: %q", policy)
+	}
+}
+
 func (w *deadlineRecorder) SetWriteDeadline(deadline time.Time) error {
 	w.deadline = deadline
 	w.called = true

--- a/mongo_store_factory.go
+++ b/mongo_store_factory.go
@@ -7,13 +7,17 @@ import (
 )
 
 func newMongoStore(ctx context.Context, mongo *Mongo) (*bmongo.MongoStore, error) {
-	return bmongo.NewMongoStore(ctx, bmongo.Config{
+	return bmongo.NewMongoStore(ctx, mongo.mongoStoreConfig("event"))
+}
+
+func (mongo *Mongo) mongoStoreConfig(collection string) bmongo.Config {
+	return bmongo.Config{
 		Host: mongo.Host, Port: mongo.Port, Database: mongo.Database,
-		Collection: mongo.Collections["event"].Name,
+		Collection: mongo.collectionName(collection, ""),
 		Username:   mongo.UserName, Password: mongo.Password,
 		ConnectTimeout: mongo.ConnectTimeOut, MaxConnIdleTime: mongo.MaxConnectionLifeTime,
 		MaxPoolSize: mongo.MaxConnectionPoolSize,
 		TLSOn:       mongo.SSL.On, CAFile: mongo.SSL.CAFile,
 		VerifyCertificate: mongo.SSL.Verify, HotReload: mongo.SSL.HotReload,
-	})
+	}
 }

--- a/redis_config_validation_test.go
+++ b/redis_config_validation_test.go
@@ -1,0 +1,22 @@
+package beanq
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedisClusterRequiresDatabaseZero(t *testing.T) {
+	cfg := &BeanqConfig{Broker: "redis", Redis: Redis{IsCluster: true, Host: "127.0.0.1", Port: "6379", Database: 1}}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "database must be 0") {
+		t.Fatalf("expected cluster database validation error, got %v", err)
+	}
+}
+
+func TestStandaloneRedisRejectsMultipleAddresses(t *testing.T) {
+	cfg := &BeanqConfig{Broker: "redis", Redis: Redis{Host: "127.0.0.1,127.0.0.2", Port: "6379"}}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "isCluster=true") {
+		t.Fatalf("expected explicit cluster validation error, got %v", err)
+	}
+}

--- a/redis_errors.go
+++ b/redis_errors.go
@@ -1,0 +1,11 @@
+package beanq
+
+import "github.com/retail-ai-inc/beanq/v4/internal/driver/bredis"
+
+var (
+	ErrAmbiguousCommit = bredis.ErrAmbiguousCommit
+	ErrClusterRouting  = bredis.ErrClusterRouting
+)
+
+type ReplicationNotConfirmedError = bredis.ReplicationNotConfirmedError
+type ClusterRoutingError = bredis.ClusterRoutingError

--- a/ui.go
+++ b/ui.go
@@ -125,7 +125,7 @@ func (c *Client) historyMongoStore() *bmongo.BMongo {
 		mongoCfg.UserName,
 		mongoCfg.Password,
 		mongoCfg.Database,
-		uiCollectionNames(mongoCfg),
+		mongoCfg.collectionNames(),
 		mongoCfg.ConnectTimeOut,
 		mongoCfg.MaxConnectionPoolSize,
 		mongoCfg.MaxConnectionLifeTime,
@@ -162,7 +162,7 @@ func (c *Client) workflowMongoCollection(ctx context.Context) (*mongo.Collection
 		}
 	}
 
-	collection := client.Database(mongoCfg.Database).Collection(uiCollectionName(mongoCfg, "workflow", "workflow_records"))
+	collection := client.Database(mongoCfg.Database).Collection(mongoCfg.collectionName("workflow", "workflow_records"))
 	return collection, disconnect, nil
 }
 
@@ -230,24 +230,6 @@ func uiListenAddr(port string) (string, error) {
 
 func uiMongoPort(port string) string {
 	return fmt.Sprintf(":%s", strings.TrimLeft(port, ":"))
-}
-
-func uiCollectionNames(config *Mongo) map[string]string {
-	collections := make(map[string]string, len(config.Collections))
-	for name, collection := range config.Collections {
-		collections[name] = collection.Name
-	}
-	return collections
-}
-
-func uiCollectionName(config *Mongo, key, fallback string) string {
-	if config == nil {
-		return fallback
-	}
-	if collection, ok := config.Collections[key]; ok && collection.Name != "" {
-		return collection.Name
-	}
-	return fallback
 }
 
 func staticFileInfo(source fs.FS) (map[string]time.Time, error) {

--- a/ui_test.go
+++ b/ui_test.go
@@ -41,19 +41,19 @@ func TestUIListenAddr(t *testing.T) {
 	}
 }
 
-func TestUICollectionName(t *testing.T) {
+func TestMongoCollectionName(t *testing.T) {
 	cfg := &Mongo{Collections: map[string]Collection{
 		"workflow": {Name: "workflow_custom"},
 		"empty":    {Name: ""},
 	}}
 
-	if got := uiCollectionName(cfg, "workflow", "workflow_records"); got != "workflow_custom" {
+	if got := cfg.collectionName("workflow", "workflow_records"); got != "workflow_custom" {
 		t.Fatalf("expected configured workflow collection, got %q", got)
 	}
-	if got := uiCollectionName(cfg, "missing", "fallback"); got != "fallback" {
+	if got := cfg.collectionName("missing", "fallback"); got != "fallback" {
 		t.Fatalf("expected fallback collection, got %q", got)
 	}
-	if got := uiCollectionName(cfg, "empty", "fallback"); got != "fallback" {
+	if got := cfg.collectionName("empty", "fallback"); got != "fallback" {
 		t.Fatalf("expected fallback for empty collection name, got %q", got)
 	}
 }

--- a/workflow.go
+++ b/workflow.go
@@ -80,25 +80,11 @@ var (
 // InitWorkflow make workflow as an independent module
 func InitWorkflow(beanqConfig *BeanqConfig) {
 	workflowOnce.Do(func() {
-		workflowClient, workflowErr = bredis.NewRdb(
-			beanqConfig.Redis.IsCluster,
-			beanqConfig.Redis.Host,
-			beanqConfig.Redis.Port,
-			beanqConfig.Redis.Username,
-			beanqConfig.Redis.Password,
-			beanqConfig.Redis.Database,
-			beanqConfig.Redis.MaxRetries,
-			beanqConfig.Redis.DialTimeout,
-			beanqConfig.Redis.ReadTimeout,
-			beanqConfig.Redis.WriteTimeout,
-			beanqConfig.Redis.PoolTimeout,
-			beanqConfig.Redis.PoolSize,
-			beanqConfig.Redis.MinIdleConnections,
-			beanqConfig.Redis.SSL.On,
-			beanqConfig.Redis.SSL.CAFile,
-			beanqConfig.Redis.SSL.Verify,
-			beanqConfig.Redis.SSL.HotReload,
-			beanqConfig.Redis.WaitReplicas)
+		resolved, err := beanqConfig.Resolve()
+		if err != nil {
+			logger.New().Panic("new redis workflow client err:", err)
+		}
+		workflowClient, workflowErr = bredis.NewRedisClient(context.Background(), resolved.redisClientOptions())
 
 		if workflowErr != nil {
 			logger.New().Panic("new redis workflow client err:", workflowErr)

--- a/workflow.go
+++ b/workflow.go
@@ -97,7 +97,8 @@ func InitWorkflow(beanqConfig *BeanqConfig) {
 			beanqConfig.Redis.SSL.On,
 			beanqConfig.Redis.SSL.CAFile,
 			beanqConfig.Redis.SSL.Verify,
-			beanqConfig.Redis.SSL.HotReload)
+			beanqConfig.Redis.SSL.HotReload,
+			beanqConfig.Redis.WaitReplicas)
 
 		if workflowErr != nil {
 			logger.New().Panic("new redis workflow client err:", workflowErr)


### PR DESCRIPTION
# PR Template

## Description

1. Added a `wait` method to the Redis cluster; it returns once the child nodes have been notified. Note that this notification does not guarantee that the data has been successfully persisted to disk on the child nodes.
2. Added a new parameter `consumerReaderPoolSize` to improve consumer

