### PR TITLE
Fix/waitaof command

### DIFF
--- a/internal/driver/bredis/replication.go
+++ b/internal/driver/bredis/replication.go
@@ -178,14 +178,24 @@ func (w replicationWait) confirm(ctx context.Context, client redisDoer) error {
 	} else {
 		command = client.Do(ctx, "WAIT", w.replicas, waitTimeoutMilliseconds(w.timeout))
 	}
-	value, err := command.Int64()
-	if err != nil {
-		return w.notConfirmed(err)
-	}
-	return w.validateAcknowledged(value)
+	return w.waitResult(command)
 }
 
 func (w replicationWait) waitResult(waitCmd *redis.Cmd) error {
+	if w.mode == WaitModeAOF {
+		acknowledged, err := waitCmd.Int64Slice()
+		if err != nil {
+			return w.notConfirmed(err)
+		}
+		if len(acknowledged) != 2 {
+			return w.notConfirmed(fmt.Errorf("unexpected WAITAOF response length %d", len(acknowledged)))
+		}
+		if acknowledged[0] < int64(w.aofLocal) {
+			return w.notConfirmed(fmt.Errorf("WAITAOF acknowledged by %d local AOF instances, want %d", acknowledged[0], w.aofLocal))
+		}
+		return w.validateAcknowledged(acknowledged[1])
+	}
+
 	acknowledged, err := waitCmd.Int64()
 	if err != nil {
 		return w.notConfirmed(err)

--- a/internal/driver/bredis/replication_test.go
+++ b/internal/driver/bredis/replication_test.go
@@ -72,8 +72,10 @@ func (s *waitTestServer) serveConn(conn net.Conn, connection int) {
 			_, _ = writer.WriteString("-ERR unknown command 'hello'\r\n")
 		case "XADD":
 			_, _ = writer.WriteString("$3\r\n1-0\r\n")
-		case "WAIT", "WAITAOF":
+		case "WAIT":
 			_, _ = fmt.Fprintf(writer, ":%d\r\n", s.waitAcks)
+		case "WAITAOF":
+			_, _ = fmt.Fprintf(writer, "*2\r\n:1\r\n:%d\r\n", s.waitAcks)
 		case "EVAL":
 			_, _ = writer.WriteString("*3\r\n$9\r\nSCHEDULED\r\n$3\r\n1-0\r\n$1\r\n1\r\n")
 		case "INFO":


### PR DESCRIPTION
# PR Template

## Description

Fixed the issue with the waitaof command-line return value.

Fixes # (issue)

1. When using `Waitaof`, a slice is returned, whereas `Wait` returns an `int64`; handle each case accordingly.
