### PR TITLE
Feature/improve redis call

### DIFF
--- a/client.go
+++ b/client.go
@@ -309,6 +309,11 @@ func newRedisBroker(config ResolvedConfig) (Broker, *capture.Config) {
 	}
 
 	broker := bredis.NewBrokerWithOptions(driver, config.redisBrokerOptions())
+	preloadCtx, preloadCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer preloadCancel()
+	if err := broker.PreloadScripts(preloadCtx); err != nil {
+		logger.New().Panic("preload Redis scripts:", err)
+	}
 
 	var captureConfig *capture.Config
 	var migrator MigrationRunner

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.7
 	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
@@ -72,7 +73,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect

--- a/helper/tool/base_client.go
+++ b/helper/tool/base_client.go
@@ -126,6 +126,9 @@ func (unsupportedClient) DbSize(context.Context) (int64, error) {
 func (unsupportedClient) Info(context.Context) (map[string]string, error) {
 	return nil, ErrUnsupportedRedisClient
 }
+func (unsupportedClient) Snapshot(context.Context) (InfoSnapshot, error) {
+	return InfoSnapshot{}, ErrUnsupportedRedisClient
+}
 
 func (unsupportedClient) Keys(context.Context, string) ([]string, error) {
 	return nil, ErrUnsupportedRedisClient
@@ -291,6 +294,78 @@ func (t *BaseClient) Stats(ctx context.Context) (map[string]any, error) {
 
 func (t *BaseClient) DbSize(ctx context.Context) (int64, error) {
 	return t.client.DBSize(ctx).Result()
+}
+
+func (t *BaseClient) Snapshot(ctx context.Context) (InfoSnapshot, error) {
+	raw, err := t.client.Info(ctx).Result()
+	if err != nil {
+		return InfoSnapshot{}, err
+	}
+	sections, info := parseInfoSnapshot(raw)
+	return InfoSnapshot{
+		Info:     info,
+		Memory:   sections["memory"],
+		Commands: parseCommandStats(sections["commandstats"]),
+		Clients:  sections["clients"],
+		Stats:    sections["stats"],
+		Keyspace: parseKeyspace(sections["keyspace"]),
+	}, nil
+}
+
+func parseInfoSnapshot(raw string) (map[string]map[string]any, map[string]string) {
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	sections := make(map[string]map[string]any)
+	info := make(map[string]string)
+	section := ""
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.HasPrefix(line, "# ") {
+			section = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, "# ")))
+			if sections[section] == nil {
+				sections[section] = make(map[string]any)
+			}
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		info[key] = value
+		if section != "" {
+			sections[section][key] = value
+		}
+	}
+	return sections, info
+}
+
+func parseCommandStats(values map[string]any) []map[string]any {
+	commands := make(Commands, 0, len(values))
+	for key, raw := range values {
+		command := map[string]any{"command": strings.TrimPrefix(key, "cmdstat_")}
+		for _, field := range strings.Split(cast.ToString(raw), ",") {
+			name, value, ok := strings.Cut(field, "=")
+			if ok {
+				command[name] = value
+			}
+		}
+		commands = append(commands, command)
+	}
+	sort.Sort(commands)
+	return commands
+}
+
+func parseKeyspace(values map[string]any) []map[string]any {
+	keyspace := make([]map[string]any, 0, len(values))
+	for database, raw := range values {
+		entry := map[string]any{"dbname": database}
+		for _, field := range strings.Split(cast.ToString(raw), ",") {
+			name, value, ok := strings.Cut(field, "=")
+			if ok {
+				entry[name] = value
+			}
+		}
+		keyspace = append(keyspace, entry)
+	}
+	return keyspace
 }
 
 func (t *BaseClient) Info(ctx context.Context) (map[string]string, error) {

--- a/helper/tool/iclient.go
+++ b/helper/tool/iclient.go
@@ -5,6 +5,14 @@ import (
 )
 
 type (
+	InfoSnapshot struct {
+		Info     map[string]string
+		Memory   map[string]any
+		Commands []map[string]any
+		Clients  map[string]any
+		Stats    map[string]any
+		Keyspace []map[string]any
+	}
 	Key struct {
 		NodeId string
 	}
@@ -46,6 +54,7 @@ type (
 		DbSize(ctx context.Context) (int64, error)
 
 		Info(ctx context.Context) (map[string]string, error)
+		Snapshot(ctx context.Context) (InfoSnapshot, error)
 	}
 	// ICommand redis commands
 	ICommand interface {

--- a/internal/capture/catch_error.go
+++ b/internal/capture/catch_error.go
@@ -2,6 +2,7 @@ package capture
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
@@ -32,6 +33,33 @@ type (
 		Then []Then
 	}
 )
+
+type alertDispatcher struct {
+	queue chan func()
+}
+
+func newAlertDispatcher(workers, capacity int) *alertDispatcher {
+	dispatcher := &alertDispatcher{queue: make(chan func(), capacity)}
+	for range max(workers, 1) {
+		go func() {
+			for job := range dispatcher.queue {
+				job()
+			}
+		}()
+	}
+	return dispatcher
+}
+
+func (d *alertDispatcher) submit(job func()) bool {
+	select {
+	case d.queue <- job:
+		return true
+	default:
+		return false
+	}
+}
+
+var defaultAlertDispatcher = newAlertDispatcher(4, 128)
 
 var (
 	System CatchType = "system"
@@ -118,15 +146,16 @@ func (t *Catch) If(chl *Channel) *Catch {
 }
 
 func (t *Catch) Then(err error) {
-
-	if t == nil {
+	if t == nil || err == nil {
 		return
 	}
-
-	if err == nil {
-		return
+	message := err.Error()
+	if !defaultAlertDispatcher.submit(func() { t.send(message) }) {
+		logger.New().Error(fmt.Errorf("BeanQ alert queue is full; dropping alert"))
 	}
+}
 
+func (t *Catch) send(message string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -143,7 +172,7 @@ func (t *Catch) Then(err error) {
 				} else {
 					client.From(user)
 					client.Subject("BeanQ alert")
-					client.TextBody(err.Error())
+					client.TextBody(message)
 					client.To(then.Value)
 					if sendErr := client.SendContext(ctx); sendErr == nil {
 						continue
@@ -155,7 +184,6 @@ func (t *Catch) Then(err error) {
 			if t.config.Email.SendGrid.Key == "" {
 				continue
 			}
-
 			client, clientErr := email.NewSendGrid(t.config.Email.SendGrid.Key)
 			if clientErr != nil {
 				logger.New().Error(clientErr)
@@ -164,26 +192,21 @@ func (t *Catch) Then(err error) {
 			client.From(t.config.Email.SendGrid.FromAddress)
 			client.FromName(t.config.Email.SendGrid.FromName)
 			client.Subject("BeanQ alert")
-			client.TextBody(err.Error())
+			client.TextBody(message)
 			client.To(then.Value)
 			if sendErr := client.SendContext(ctx); sendErr != nil {
 				logger.New().Error(sendErr)
-				continue
 			}
 		}
 		if then.Key == "slack" {
-			if t.config.Slack.BotAuthToken == "" {
+			if t.config.Slack.BotAuthToken == "" || (then.Parameters.Channel == "" && then.Parameters.WorkSpace == "") {
 				continue
 			}
-			if then.Parameters.Channel == "" && then.Parameters.WorkSpace == "" {
-				continue
-			}
-			xclient := xslack.NewClient(t.config.Slack.BotAuthToken)
-			xclient.Channel(then.Parameters.Channel)
-			xclient.Color(xslack.Danger)
-
-			if err := xclient.Send(ctx, xslack.Field{Title: "Beanq Error", Value: err.Error(), Short: true}); err != nil {
-				logger.New().Error(err)
+			client := xslack.NewClient(t.config.Slack.BotAuthToken)
+			client.Channel(then.Parameters.Channel)
+			client.Color(xslack.Danger)
+			if sendErr := client.Send(ctx, xslack.Field{Title: "Beanq Error", Value: message, Short: true}); sendErr != nil {
+				logger.New().Error(sendErr)
 			}
 		}
 	}

--- a/internal/driver/bredis/args_pool.go
+++ b/internal/driver/bredis/args_pool.go
@@ -13,7 +13,7 @@ func NewZAddArgs(stream, minId, Id string, maxLen, Limit int64, vals any) *redis
 		NoMkStream: false,
 		MaxLen:     maxLen,
 		MinID:      minId,
-		Approx:     false,
+		Approx:     true,
 		Limit:      Limit,
 		ID:         Id,
 		Values:     vals,

--- a/internal/driver/bredis/broker.go
+++ b/internal/driver/bredis/broker.go
@@ -123,12 +123,13 @@ func NewBrokerWithOptions(client redis.UniversalClient, options BrokerOptions) *
 		mode: options.ReplicationWait.Mode, replicas: options.ReplicationWait.Replicas,
 		aofLocal: options.ReplicationWait.AOFLocal, timeout: options.ReplicationWait.Timeout,
 	}
+	metadataCache := &metadataValidationCache{}
 	queue := func(partitions int64, config *capture.Config) queueOptions {
 		return queueOptions{
 			client: client, prefix: options.Prefix, maxLen: options.MaxLen, partitions: partitions,
 			runtime:        queueRuntimeOptions{workers: options.ConsumerWorkers, readers: options.ConsumerReaders},
 			deadLetterIdle: options.DeadLetterIdle, gracefulShutdownTimeout: options.GracefulShutdownTimeout,
-			captureConfig: config, wait: wait,
+			captureConfig: config, wait: wait, metadataCache: metadataCache,
 		}
 	}
 	normal := func(config *capture.Config) *Normal {

--- a/internal/driver/bredis/broker.go
+++ b/internal/driver/bredis/broker.go
@@ -228,6 +228,13 @@ func (t *Broker) QueueMessage(ctx context.Context) error {
 	return t.admin.QueueMessage(ctx)
 }
 
+func (t *Broker) PreloadScripts(ctx context.Context) error {
+	if t == nil || t.client == nil {
+		return nil
+	}
+	return DefaultScriptCatalog().Load(ctx, t.client)
+}
+
 func (t *Broker) Driver() any {
 	return t.client
 }

--- a/internal/driver/bredis/delay_queue_runtime.go
+++ b/internal/driver/bredis/delay_queue_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/retail-ai-inc/beanq/v4/helper/logger"
@@ -11,9 +12,26 @@ import (
 	"github.com/rs/xid"
 )
 
+const (
+	delaySchedulerConcurrency  = 8
+	delaySchedulerInitialDelay = 100 * time.Millisecond
+	delaySchedulerMaxDelay     = time.Second
+)
+
 type delayQueueRuntime struct {
 	store   *delayQueueStore
 	runtime *partitionRuntime[streamQueueDispatch]
+}
+
+type delayPartitionSchedule struct {
+	next  time.Time
+	delay time.Duration
+}
+
+type delayPromotionResult struct {
+	partition int64
+	promoted  bool
+	err       error
 }
 
 func newDelayQueueRuntime(store *delayQueueStore, base *queueBase) *delayQueueRuntime {
@@ -34,25 +52,94 @@ func (r *delayQueueRuntime) run(ctx context.Context, channel, topic string, hand
 }
 
 func (r *delayQueueRuntime) scheduler(ctx context.Context) {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	states := make([]delayPartitionSchedule, r.store.topology.partitions)
 	for ctx.Err() == nil {
-		active := false
 		now := time.Now()
-		for partition := int64(0); partition < r.store.topology.partitions; partition++ {
-			promoted, err := r.store.promote(ctx, partition, now)
-			if err != nil && !errors.Is(err, context.Canceled) {
-				logger.New().Error(fmt.Errorf("delay queue promote partition %d: %w", partition, err))
+		due := make([]int64, 0, len(states))
+		for partition := range states {
+			if states[partition].next.IsZero() || !now.Before(states[partition].next) {
+				due = append(due, int64(partition))
 			}
-			active = active || promoted
+		}
+		if len(due) == 0 {
+			if !waitDelayScheduler(ctx, nextDelaySchedulerWake(states, now)) {
+				return
+			}
+			continue
+		}
+
+		results := make(chan delayPromotionResult, len(due))
+		for start := 0; start < len(due); start += delaySchedulerConcurrency {
+			end := min(start+delaySchedulerConcurrency, len(due))
+			var workers sync.WaitGroup
+			for _, partition := range due[start:end] {
+				workers.Add(1)
+				go func(partition int64) {
+					defer workers.Done()
+					promoted, err := r.store.promote(ctx, partition, now)
+					results <- delayPromotionResult{partition: partition, promoted: promoted, err: err}
+				}(partition)
+			}
+			workers.Wait()
+		}
+		close(results)
+
+		active := false
+		for result := range results {
+			state := &states[result.partition]
+			if result.err != nil && !errors.Is(result.err, context.Canceled) {
+				logger.New().Error(fmt.Errorf("delay queue promote partition %d: %w", result.partition, result.err))
+			}
+			if result.promoted {
+				state.reset()
+				active = true
+			} else {
+				state.advance()
+			}
 		}
 		if active {
 			continue
 		}
-		select {
-		case <-ctx.Done():
+		if !waitDelayScheduler(ctx, nextDelaySchedulerWake(states, time.Now())) {
 			return
-		case <-ticker.C:
 		}
+	}
+}
+
+func (s *delayPartitionSchedule) advance() {
+	if s.delay <= 0 {
+		s.delay = delaySchedulerInitialDelay
+	} else {
+		s.delay = min(s.delay*2, delaySchedulerMaxDelay)
+	}
+	jitterRange := max(s.delay/5, time.Nanosecond)
+	jitter := time.Duration(time.Now().UnixNano() % int64(jitterRange))
+	s.next = time.Now().Add(s.delay + jitter)
+}
+
+func (s *delayPartitionSchedule) reset() {
+	s.delay = 0
+	s.next = time.Time{}
+}
+
+func nextDelaySchedulerWake(states []delayPartitionSchedule, now time.Time) time.Duration {
+	delay := delaySchedulerMaxDelay
+	for _, state := range states {
+		if state.next.IsZero() || !now.Before(state.next) {
+			return 0
+		}
+		delay = min(delay, state.next.Sub(now))
+	}
+	return max(delay, time.Nanosecond)
+}
+
+func waitDelayScheduler(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }

--- a/internal/driver/bredis/delay_queue_store.go
+++ b/internal/driver/bredis/delay_queue_store.go
@@ -14,10 +14,11 @@ import (
 const delayQueuePromoteBatch = int64(100)
 
 type delayQueueStore struct {
-	client   redis.UniversalClient
-	topology delayQueueTopology
-	maxLen   int64
-	wait     replicationWait
+	client        redis.UniversalClient
+	topology      delayQueueTopology
+	maxLen        int64
+	wait          replicationWait
+	metadataCache *metadataValidationCache
 }
 
 func newDelayQueueStore(client redis.UniversalClient, topology delayQueueTopology, maxLen int64, waits ...replicationWait) *delayQueueStore {
@@ -32,7 +33,9 @@ func (s *delayQueueStore) metadata() partitionQueueMetadata {
 }
 
 func (s *delayQueueStore) ensureMetadata(ctx context.Context) error {
-	return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "delay queue", s.metadata())
+	return s.metadataCache.ensure(ctx, s.topology.metadataKey(), s.metadata().canonicalConfig(), func(ctx context.Context) error {
+		return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "delay queue", s.metadata())
+	})
 }
 
 func (s *delayQueueStore) bootstrapGroups(ctx context.Context, group string) error {
@@ -100,7 +103,8 @@ func (s *delayQueueStore) promote(ctx context.Context, partition int64, now time
 		}
 		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 			for _, data := range decoded {
-				pipe.XAdd(ctx, NewZAddArgs(stream, "", "*", s.maxLen, 0, data))
+				args := NewZAddArgs(stream, "", "*", s.maxLen, 0, data)
+				pipe.XAdd(ctx, args)
 			}
 			// Invalid entries are removed too; otherwise they permanently block the head.
 			members := make([]any, len(values))

--- a/internal/driver/bredis/metadata_cache.go
+++ b/internal/driver/bredis/metadata_cache.go
@@ -1,0 +1,34 @@
+package bredis
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type metadataValidationCache struct {
+	verified sync.Map
+	group    singleflight.Group
+}
+
+func (c *metadataValidationCache) ensure(ctx context.Context, key, canonical string, validate func(context.Context) error) error {
+	if c == nil {
+		return validate(ctx)
+	}
+	cacheKey := key + "\x00" + canonical
+	if _, ok := c.verified.Load(cacheKey); ok {
+		return nil
+	}
+	_, err, _ := c.group.Do(cacheKey, func() (any, error) {
+		if _, ok := c.verified.Load(cacheKey); ok {
+			return nil, nil
+		}
+		if err := validate(ctx); err != nil {
+			return nil, err
+		}
+		c.verified.Store(cacheKey, struct{}{})
+		return nil, nil
+	})
+	return err
+}

--- a/internal/driver/bredis/normal.go
+++ b/internal/driver/bredis/normal.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Normal struct {
-	base       queueBase
-	maxLen     int64
-	partitions int64
-	wait       replicationWait
+	base          queueBase
+	maxLen        int64
+	partitions    int64
+	wait          replicationWait
+	metadataCache *metadataValidationCache
 }
 
 func NewNormal(client redis.UniversalClient, prefix string, maxLen int64, consumerCount int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Normal {
@@ -34,11 +35,14 @@ func newNormalWithOptions(options queueOptions) *Normal {
 	base.processLogger = NewProcessLogWithPartitions(options.client, options.prefix, options.partitions, 0)
 	return &Normal{
 		maxLen: options.maxLen, partitions: options.partitions, wait: options.wait, base: base,
+		metadataCache: options.metadataCache,
 	}
 }
 
 func (t *Normal) store(channel, topic string) *normalQueueStore {
-	return newNormalQueueStore(t.base.client, newNormalQueueTopology(t.base.prefix, channel, topic, t.partitions), t.maxLen, t.wait)
+	store := newNormalQueueStore(t.base.client, newNormalQueueTopology(t.base.prefix, channel, topic, t.partitions), t.maxLen, t.wait)
+	store.metadataCache = t.metadataCache
+	return store
 }
 
 func (t *Normal) Publish(ctx context.Context, data map[string]any) error {

--- a/internal/driver/bredis/normal_queue_store.go
+++ b/internal/driver/bredis/normal_queue_store.go
@@ -7,10 +7,11 @@ import (
 )
 
 type normalQueueStore struct {
-	client   redis.UniversalClient
-	topology normalQueueTopology
-	maxLen   int64
-	wait     replicationWait
+	client        redis.UniversalClient
+	topology      normalQueueTopology
+	maxLen        int64
+	wait          replicationWait
+	metadataCache *metadataValidationCache
 }
 
 func newNormalQueueStore(client redis.UniversalClient, topology normalQueueTopology, maxLen int64, waits ...replicationWait) *normalQueueStore {
@@ -29,7 +30,9 @@ func (s *normalQueueStore) metadata() partitionQueueMetadata {
 }
 
 func (s *normalQueueStore) ensureMetadata(ctx context.Context) error {
-	return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "normal queue", s.metadata())
+	return s.metadataCache.ensure(ctx, s.topology.metadataKey(), s.metadata().canonicalConfig(), func(ctx context.Context) error {
+		return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "normal queue", s.metadata())
+	})
 }
 
 func validateNormalQueueMetadata(got, want string) error {

--- a/internal/driver/bredis/partition_queue_common.go
+++ b/internal/driver/bredis/partition_queue_common.go
@@ -13,9 +13,12 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/retail-ai-inc/beanq/v4/helper/tool"
 	"github.com/retail-ai-inc/beanq/v4/internal/boptions"
+	"golang.org/x/sync/errgroup"
 )
 
 const partitionQueueDefaultMaxLen int64 = 200000
+
+const partitionGroupBootstrapConcurrency = 8
 
 const (
 	partitionReaderIdleDelay = 20 * time.Millisecond
@@ -162,12 +165,15 @@ func validatePartitionQueueMetadata(got, want, queueName string) error {
 }
 
 func bootstrapPartitionGroups(ctx context.Context, client redis.UniversalClient, group, queueName string, partitions int64, streamKey func(int64) string) error {
+	workers, workerCtx := errgroup.WithContext(ctx)
+	workers.SetLimit(partitionGroupBootstrapConcurrency)
 	for partition := int64(0); partition < partitions; partition++ {
-		if err := bootstrapPartitionGroup(ctx, client, group, queueName, partition, streamKey(partition)); err != nil {
-			return err
-		}
+		partition := partition
+		workers.Go(func() error {
+			return bootstrapPartitionGroup(workerCtx, client, group, queueName, partition, streamKey(partition))
+		})
 	}
-	return nil
+	return workers.Wait()
 }
 
 func bootstrapPartitionGroup(ctx context.Context, client redis.UniversalClient, group, queueName string, partition int64, stream string) error {

--- a/internal/driver/bredis/partition_queue_common.go
+++ b/internal/driver/bredis/partition_queue_common.go
@@ -19,6 +19,7 @@ const partitionQueueDefaultMaxLen int64 = 200000
 
 const (
 	partitionReaderIdleDelay = 20 * time.Millisecond
+	partitionReaderMaxDelay  = 500 * time.Millisecond
 	partitionClaimInterval   = time.Second
 	partitionNonBlockingRead = -1 * time.Nanosecond
 )

--- a/internal/driver/bredis/partition_runtime.go
+++ b/internal/driver/bredis/partition_runtime.go
@@ -37,6 +37,8 @@ type partitionRuntime[T any] struct {
 type partitionReaderState struct {
 	cursor    string
 	nextClaim time.Time
+	nextRead  time.Time
+	idleDelay time.Duration
 }
 
 func newPartitionRuntime[T any](adapter partitionRuntimeAdapter[T]) *partitionRuntime[T] {
@@ -146,6 +148,12 @@ func (r *partitionRuntime[T]) pollPartition(ctx context.Context, group, consumer
 			}
 		}
 	}
+	if active {
+		state.resetReadBackoff()
+	}
+	if time.Now().Before(state.nextRead) {
+		return active, ctx.Err() == nil
+	}
 
 	items, err := r.adapter.Read(ctx, group, consumer, partition)
 	if err != nil {
@@ -158,15 +166,39 @@ func (r *partitionRuntime[T]) pollPartition(ctx context.Context, group, consumer
 		if !ignorablePartitionReadError(ctx, err) {
 			r.logError("read", partition, err)
 		}
+		if errors.Is(err, redis.Nil) {
+			state.advanceReadBackoff()
+		}
 		return active, ctx.Err() == nil
 	}
 	active = active || len(items) > 0
+	if len(items) == 0 {
+		state.advanceReadBackoff()
+	} else {
+		state.resetReadBackoff()
+	}
 	for _, item := range items {
 		if !sendPartitionDispatch(ctx, dispatch, partitionDispatch[T]{consumer: consumer, item: item}) {
 			return active, false
 		}
 	}
 	return active, ctx.Err() == nil
+}
+
+func (s *partitionReaderState) advanceReadBackoff() {
+	if s.idleDelay <= 0 {
+		s.idleDelay = partitionReaderIdleDelay
+	} else {
+		s.idleDelay = min(s.idleDelay*2, partitionReaderMaxDelay)
+	}
+	jitterRange := max(s.idleDelay/5, time.Nanosecond)
+	jitter := time.Duration(time.Now().UnixNano() % int64(jitterRange))
+	s.nextRead = time.Now().Add(s.idleDelay + jitter)
+}
+
+func (s *partitionReaderState) resetReadBackoff() {
+	s.idleDelay = 0
+	s.nextRead = time.Time{}
 }
 
 func (r *partitionRuntime[T]) worker(ctx context.Context, channel, topic string, dispatch <-chan partitionDispatch[T], handler public.CallbackWithRetry) {

--- a/internal/driver/bredis/schedule.go
+++ b/internal/driver/bredis/schedule.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Schedule struct {
-	base       queueBase
-	maxLen     int64
-	partitions int64
-	wait       replicationWait
+	base          queueBase
+	maxLen        int64
+	partitions    int64
+	wait          replicationWait
+	metadataCache *metadataValidationCache
 }
 
 func NewSchedule(client redis.UniversalClient, prefix string, consumerCount int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *Schedule {
@@ -32,11 +33,14 @@ func newScheduleWithOptions(options queueOptions) *Schedule {
 	base.processLogger = NewProcessLogWithPartitions(options.client, options.prefix, options.partitions, 0)
 	return &Schedule{
 		maxLen: options.maxLen, partitions: options.partitions, wait: options.wait, base: base,
+		metadataCache: options.metadataCache,
 	}
 }
 
 func (s *Schedule) store(channel, topic string) *delayQueueStore {
-	return newDelayQueueStore(s.base.client, newDelayQueueTopology(s.base.prefix, channel, topic, s.partitions), s.maxLen, s.wait)
+	store := newDelayQueueStore(s.base.client, newDelayQueueTopology(s.base.prefix, channel, topic, s.partitions), s.maxLen, s.wait)
+	store.metadataCache = s.metadataCache
+	return store
 }
 
 func (s *Schedule) Publish(ctx context.Context, data map[string]any) error {

--- a/internal/driver/bredis/scripts.go
+++ b/internal/driver/bredis/scripts.go
@@ -82,6 +82,18 @@ func DefaultScriptCatalog() *ScriptCatalog {
 	return defaultScriptCatalog
 }
 
+func (c *ScriptCatalog) Load(ctx context.Context, client redis.Scripter) error {
+	if c == nil {
+		return fmt.Errorf("redis script catalog is nil")
+	}
+	for name, script := range c.scripts {
+		if _, err := script.Load(ctx, client).Result(); err != nil {
+			return fmt.Errorf("load redis script %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
 func (c *ScriptCatalog) Run(ctx context.Context, client redis.Scripter, name string, keys []string, args ...any) (any, error) {
 	if c == nil {
 		return nil, fmt.Errorf("redis script catalog is nil")

--- a/internal/driver/bredis/scripts/saveBranches.lua
+++ b/internal/driver/bredis/scripts/saveBranches.lua
@@ -16,10 +16,12 @@ if start == "-1" then
 	end
 end
 
-for k = 5, table.getn(ARGV) do
-	if start == "-1" then
-		redis.call('RPUSH', KEYS[2], ARGV[k])
-	else
+if start == "-1" then
+	if table.getn(ARGV) >= 5 then
+		redis.call('RPUSH', KEYS[2], unpack(ARGV, 5, table.getn(ARGV)))
+	end
+else
+	for k = 5, table.getn(ARGV) do
 		redis.call('LSET', KEYS[2], start+k-5, ARGV[k])
 	end
 end

--- a/internal/driver/bredis/scripts/saveHSet.lua
+++ b/internal/driver/bredis/scripts/saveHSet.lua
@@ -1,10 +1,7 @@
 local key = KEYS[1]
-local data = ARGV
 
-for i = 1, #data, 2 do
-    local field = data[i]
-    local value = data[i + 1]
-    redis.call('HSET', key, field, value)
+if #ARGV > 0 then
+    redis.call('HSET', key, unpack(ARGV))
 end
 
 local ttl = 3600*6

--- a/internal/driver/bredis/scripts/saveNewTrans.lua
+++ b/internal/driver/bredis/scripts/saveNewTrans.lua
@@ -7,8 +7,8 @@ end
 redis.call('SET', KEYS[1], ARGV[3], 'EX', ARGV[2])
 redis.call('SET', KEYS[4], ARGV[6], 'EX', ARGV[2])
 redis.call('ZADD', KEYS[3], ARGV[4], ARGV[5])
-for k = 7, table.getn(ARGV) do
-	redis.call('RPUSH', KEYS[2], ARGV[k])
+if table.getn(ARGV) >= 7 then
+	redis.call('RPUSH', KEYS[2], unpack(ARGV, 7, table.getn(ARGV)))
 end
 redis.call('EXPIRE', KEYS[2], ARGV[2])
 

--- a/internal/driver/bredis/scripts/sequenceQueueEnqueue.lua
+++ b/internal/driver/bredis/scripts/sequenceQueueEnqueue.lua
@@ -24,25 +24,29 @@ if capacity == nil or capacity <= 0 then
     return result('BAD_CAPACITY')
 end
 
-local storedCapacity = tonumber(redis.call('HGET', partitionState, 'capacity') or '0')
+local partitionValues = redis.call('HMGET', partitionState, 'capacity', 'count')
+local storedCapacity = tonumber(partitionValues[1] or '0')
+local count = tonumber(partitionValues[2] or '0')
 if storedCapacity == 0 then
-    redis.call('HSET', partitionState, 'capacity', tostring(capacity), 'count', redis.call('HGET', partitionState, 'count') or '0')
+    redis.call('HSET', partitionState, 'capacity', tostring(capacity), 'count', tostring(count))
 elseif storedCapacity ~= capacity then
     return result('CONFIG_MISMATCH', tostring(storedCapacity), 0)
 end
 
-local count = tonumber(redis.call('HGET', partitionState, 'count') or '0')
 if count >= capacity then
     return result('FULL', tostring(capacity), count)
 end
 
 local stateExists = redis.call('EXISTS', orderState) == 1
 local queueLength = redis.call('LLEN', orderQueue)
+local schedulerID = ''
 if stateExists then
-    local stateOrderKey = redis.call('HGET', orderState, 'order_key')
-    local phase = redis.call('HGET', orderState, 'phase')
-    local depth = tonumber(redis.call('HGET', orderState, 'depth') or '-1')
-    local schedulerID = redis.call('HGET', orderState, 'scheduler_id') or ''
+    local stateValues = redis.call('HMGET', orderState,
+        'order_key', 'phase', 'depth', 'scheduler_id')
+    local stateOrderKey = stateValues[1]
+    local phase = stateValues[2]
+    local depth = tonumber(stateValues[3] or '-1')
+    schedulerID = stateValues[4] or ''
     if stateOrderKey ~= orderKey or phase == 'corrupt' or
        (phase ~= 'ready' and phase ~= 'owned') or depth ~= queueLength or
        depth <= 0 or schedulerID == '' then
@@ -74,4 +78,4 @@ if not stateExists then
 end
 
 redis.call('HINCRBY', orderState, 'depth', 1)
-return result('QUEUED', redis.call('HGET', orderState, 'scheduler_id'), count)
+return result('QUEUED', schedulerID, count)

--- a/internal/driver/bredis/scripts/sequenceQueueFinalize.lua
+++ b/internal/driver/bredis/scripts/sequenceQueueFinalize.lua
@@ -35,18 +35,26 @@ if redis.call('EXISTS', orderState) == 0 then
     discard('orphan_token')
     return result('ORPHAN_CLEANED')
 end
-if redis.call('HGET', orderState, 'order_key') ~= orderKey then
+local stateValues = redis.call('HMGET', orderState,
+    'order_key', 'scheduler_id', 'phase',
+    'acquisition_id', 'consumer', 'depth')
+local stateOrderKey = stateValues[1]
+local stateSchedulerID = stateValues[2]
+local phase = stateValues[3]
+local stateAcquisitionID = stateValues[4]
+local stateConsumer = stateValues[5]
+local depth = tonumber(stateValues[6] or '-1')
+if stateOrderKey ~= orderKey then
     redis.call('HSET', orderState, 'phase', 'corrupt', 'corrupt_reason', 'order_key_mismatch')
     discard('order_key_mismatch')
     return result('ISOLATED')
 end
-if redis.call('HGET', orderState, 'scheduler_id') ~= schedulerID then
+if stateSchedulerID ~= schedulerID then
     discard('stale_token')
     return result('STALE_CLEANED')
 end
-if redis.call('HGET', orderState, 'phase') ~= 'owned' or
-   redis.call('HGET', orderState, 'acquisition_id') ~= acquisitionID or
-   redis.call('HGET', orderState, 'consumer') ~= consumer then
+if phase ~= 'owned' or stateAcquisitionID ~= acquisitionID or
+   stateConsumer ~= consumer then
     return result('STALE_ACQUISITION')
 end
 
@@ -60,13 +68,11 @@ end
 
 local head = redis.call('LINDEX', orderQueue, 0)
 if not head then
-    local depth = tonumber(redis.call('HGET', orderState, 'depth') or '0')
     local count = tonumber(redis.call('HGET', partitionState, 'count') or '0')
     count = math.max(0, count - math.max(0, depth))
     redis.call('HSET', partitionState, 'count', tostring(count))
     discard('empty_queue')
-    redis.call('DEL', orderState)
-    redis.call('DEL', orderQueue)
+    redis.call('DEL', orderState, orderQueue)
     return result('EMPTY_CLEANED', '', count)
 end
 if head ~= expectedHead then
@@ -76,7 +82,6 @@ if head ~= expectedHead then
 end
 
 local count = tonumber(redis.call('HGET', partitionState, 'count') or '-1')
-local depth = tonumber(redis.call('HGET', orderState, 'depth') or '-1')
 local actualDepth = redis.call('LLEN', orderQueue)
 if count <= 0 or depth <= 0 or depth ~= actualDepth then
     redis.call('HSET', orderState, 'phase', 'corrupt', 'corrupt_reason', 'counter_mismatch')
@@ -101,6 +106,5 @@ if depth > 0 then
     return result('SUCCESSOR', successorID, depth)
 end
 
-redis.call('DEL', orderState)
-redis.call('DEL', orderQueue)
+redis.call('DEL', orderState, orderQueue)
 return result('EMPTY', '', 0)

--- a/internal/driver/bredis/scripts/sequenceQueueLease.lua
+++ b/internal/driver/bredis/scripts/sequenceQueueLease.lua
@@ -46,16 +46,24 @@ if redis.call('EXISTS', orderState) == 0 then
     discard('orphan_token')
     return result('ORPHAN_CLEANED')
 end
-if redis.call('HGET', orderState, 'order_key') ~= orderKey then
+local stateValues = redis.call('HMGET', orderState,
+    'order_key', 'scheduler_id', 'phase', 'depth',
+    'acquisition_id', 'consumer', 'deadline_ms')
+local stateOrderKey = stateValues[1]
+local stateSchedulerID = stateValues[2]
+local phase = stateValues[3]
+local depth = tonumber(stateValues[4] or '-1')
+local currentAcquisition = stateValues[5] or ''
+local currentConsumer = stateValues[6] or ''
+local currentDeadline = tonumber(stateValues[7] or '0')
+if stateOrderKey ~= orderKey then
     discard('order_key_mismatch')
     return result('ISOLATED')
 end
-if redis.call('HGET', orderState, 'scheduler_id') ~= schedulerID then
+if stateSchedulerID ~= schedulerID then
     discard('stale_token')
     return result('STALE_CLEANED')
 end
-local phase = redis.call('HGET', orderState, 'phase')
-local depth = tonumber(redis.call('HGET', orderState, 'depth') or '-1')
 if phase == 'corrupt' or (phase ~= 'ready' and phase ~= 'owned') or depth <= 0 then
     redis.call('HSET', orderState, 'phase', 'corrupt', 'corrupt_reason', 'invalid_state')
     discard('invalid_state')
@@ -72,22 +80,17 @@ end
 
 local head = redis.call('LINDEX', orderQueue, 0)
 if not head then
-    local depth = tonumber(redis.call('HGET', orderState, 'depth') or '0')
     local count = tonumber(redis.call('HGET', partitionState, 'count') or '0')
     count = math.max(0, count - math.max(0, depth))
     redis.call('HSET', partitionState, 'count', tostring(count))
     discard('empty_queue')
-    redis.call('DEL', orderState)
-    redis.call('DEL', orderQueue)
+    redis.call('DEL', orderState, orderQueue)
     return result('EMPTY_CLEANED', '', count)
 end
 
 local now = redis.call('TIME')
 local nowMS = tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
 local deadline = nowMS + leaseMS
-local currentAcquisition = redis.call('HGET', orderState, 'acquisition_id') or ''
-local currentConsumer = redis.call('HGET', orderState, 'consumer') or ''
-local currentDeadline = tonumber(redis.call('HGET', orderState, 'deadline_ms') or '0')
 
 if operation == 'renew' then
     if phase ~= 'owned' or currentAcquisition ~= acquisitionID or currentConsumer ~= consumer then

--- a/internal/driver/bredis/scripts_optimization_test.go
+++ b/internal/driver/bredis/scripts_optimization_test.go
@@ -1,0 +1,80 @@
+package bredis
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHashAndListScriptsUseBulkCommands(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		call   string
+		guard  string
+	}{
+		{
+			name:   "save hash",
+			script: saveHsetLua,
+			call:   "redis.call('HSET', key, unpack(ARGV))",
+			guard:  "if #ARGV > 0 then",
+		},
+		{
+			name:   "save branches",
+			script: saveBranchesLua,
+			call:   "redis.call('RPUSH', KEYS[2], unpack(ARGV, 5, table.getn(ARGV)))",
+		},
+		{
+			name:   "save transaction",
+			script: saveNewTransLua,
+			call:   "redis.call('RPUSH', KEYS[2], unpack(ARGV, 7, table.getn(ARGV)))",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !strings.Contains(test.script, test.call) {
+				t.Fatalf("script does not contain bulk call %q", test.call)
+			}
+			if test.guard != "" && !strings.Contains(test.script, test.guard) {
+				t.Fatalf("script does not contain empty-input guard %q", test.guard)
+			}
+		})
+	}
+}
+
+func TestSequenceQueueScriptsBatchHashReads(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		wantHMGet int
+		wantHGet  int
+	}{
+		{name: "enqueue", script: sequenceQueueEnqueueLua, wantHMGet: 2},
+		{name: "lease", script: sequenceQueueLeaseLua, wantHMGet: 1, wantHGet: 1},
+		{name: "finalize", script: sequenceQueueFinalizeLua, wantHMGet: 1, wantHGet: 2},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := strings.Count(test.script, "redis.call('HMGET'"); got != test.wantHMGet {
+				t.Fatalf("HMGET calls = %d, want %d", got, test.wantHMGet)
+			}
+			if got := strings.Count(test.script, "redis.call('HGET'"); got != test.wantHGet {
+				t.Fatalf("HGET calls = %d, want %d", got, test.wantHGet)
+			}
+		})
+	}
+}
+
+func TestSequenceQueueCleanupUsesMultiKeyDelete(t *testing.T) {
+	for name, script := range map[string]string{
+		"lease":    sequenceQueueLeaseLua,
+		"finalize": sequenceQueueFinalizeLua,
+	} {
+		if strings.Contains(script, "redis.call('DEL', orderState)\n") ||
+			strings.Contains(script, "redis.call('DEL', orderQueue)\n") {
+			t.Fatalf("%s script still deletes queue keys separately", name)
+		}
+		if !strings.Contains(script, "redis.call('DEL', orderState, orderQueue)") {
+			t.Fatalf("%s script does not use multi-key DEL", name)
+		}
+	}
+}

--- a/internal/driver/bredis/sequenceQueue.go
+++ b/internal/driver/bredis/sequenceQueue.go
@@ -16,10 +16,11 @@ import (
 )
 
 type SequenceQueue struct {
-	base       queueBase
-	maxLen     int64
-	partitions int64
-	wait       replicationWait
+	base          queueBase
+	maxLen        int64
+	partitions    int64
+	wait          replicationWait
+	metadataCache *metadataValidationCache
 }
 
 func NewSequenceQueue(client redis.UniversalClient, prefix string, maxLen int64, consumerCount int64, consumerPoolSize int, deadLetterIdle time.Duration, config *capture.Config) *SequenceQueue {
@@ -36,10 +37,11 @@ func newSequenceQueueWithOptions(options queueOptions) *SequenceQueue {
 	base := newQueueBase(options)
 	base.processLogger = NewProcessLogWithPartitions(options.client, options.prefix, 0, options.partitions)
 	return &SequenceQueue{
-		maxLen:     options.maxLen,
-		partitions: options.partitions,
-		wait:       options.wait,
-		base:       base,
+		maxLen:        options.maxLen,
+		partitions:    options.partitions,
+		wait:          options.wait,
+		base:          base,
+		metadataCache: options.metadataCache,
 	}
 }
 
@@ -77,7 +79,9 @@ func (q *SequenceQueue) ConsumerSequence(ctx context.Context, channel, topic str
 
 func (q *SequenceQueue) sequenceQueueStore(channel, topic string, maxLen int64) *sequenceQueueStore {
 	topology := newSequenceQueueTopology(q.base.prefix, channel, topic, q.partitions)
-	return newSequenceQueueStore(q.base.client, topology, maxLen, q.base.deadLetterIdle, q.wait)
+	store := newSequenceQueueStore(q.base.client, topology, maxLen, q.base.deadLetterIdle, q.wait)
+	store.metadataCache = q.metadataCache
+	return store
 }
 
 func sequenceQueueFailedData(channel, topic, orderKey, raw string, cause error) map[string]any {

--- a/internal/driver/bredis/sequence_queue_runtime.go
+++ b/internal/driver/bredis/sequence_queue_runtime.go
@@ -172,13 +172,14 @@ func (r *sequenceQueueRuntime) process(ctx context.Context, channel, topic, grou
 }
 
 func (r *sequenceQueueRuntime) heartbeat(ctx context.Context, cancelLease context.CancelFunc, group, consumer, acquisitionID string, token sequenceQueueToken) {
-	ticker := time.NewTicker(r.heartbeatInterval())
-	defer ticker.Stop()
+	interval := r.heartbeatInterval()
+	timer := time.NewTimer(heartbeatDelay(interval))
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-timer.C:
 			result, err := r.store.renew(ctx, group, consumer, acquisitionID, token)
 			if err != nil {
 				if ctx.Err() == nil {
@@ -188,6 +189,7 @@ func (r *sequenceQueueRuntime) heartbeat(ctx context.Context, cancelLease contex
 				return
 			}
 			state := classifySequenceQueueStoreCode(result.Code)
+			timer.Reset(heartbeatDelay(interval))
 			if state != sequenceQueueStoreNormal || result.Code != bstatus.SequenceQueueCodeRenewed {
 				if state == sequenceQueueStoreNormal {
 					state = sequenceQueueStoreFatal
@@ -236,6 +238,18 @@ func (s sequenceQueueStoreState) String() string {
 	default:
 		return "fatal"
 	}
+}
+
+func heartbeatDelay(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return time.Second
+	}
+	jitterRange := interval / 10
+	if jitterRange <= 0 {
+		return interval
+	}
+	offset := time.Now().UnixNano()%int64(2*jitterRange+1) - int64(jitterRange)
+	return interval + time.Duration(offset)
 }
 
 func (r *sequenceQueueRuntime) heartbeatInterval() time.Duration {

--- a/internal/driver/bredis/sequence_queue_store.go
+++ b/internal/driver/bredis/sequence_queue_store.go
@@ -19,12 +19,13 @@ const (
 )
 
 type sequenceQueueStore struct {
-	client   redis.UniversalClient
-	scripts  *ScriptCatalog
-	lease    time.Duration
-	topology sequenceQueueTopology
-	maxLen   int64
-	wait     replicationWait
+	client        redis.UniversalClient
+	scripts       *ScriptCatalog
+	lease         time.Duration
+	topology      sequenceQueueTopology
+	maxLen        int64
+	wait          replicationWait
+	metadataCache *metadataValidationCache
 }
 
 type sequenceQueueToken struct {
@@ -83,7 +84,9 @@ func (s *sequenceQueueStore) metadata() partitionQueueMetadata {
 
 // ensureMetadata elects the first complete queue configuration as canonical.
 func (s *sequenceQueueStore) ensureMetadata(ctx context.Context) error {
-	return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "sequence queue", s.metadata())
+	return s.metadataCache.ensure(ctx, s.topology.metadataKey(), s.metadata().canonicalConfig(), func(ctx context.Context) error {
+		return ensurePartitionQueueMetadata(ctx, s.client, s.wait, s.topology.metadataKey(), "sequence queue", s.metadata())
+	})
 }
 
 func (s *sequenceQueueStore) bootstrapGroups(ctx context.Context, group string) error {

--- a/internal/driver/bredis/status.go
+++ b/internal/driver/bredis/status.go
@@ -2,10 +2,16 @@ package bredis
 
 import (
 	"context"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/retail-ai-inc/beanq/v4/helper/bstatus"
 	"github.com/retail-ai-inc/beanq/v4/helper/tool"
+)
+
+const (
+	statusWaitInitialDelay = 5 * time.Millisecond
+	statusWaitMaxDelay     = 200 * time.Millisecond
 )
 
 type Status struct {
@@ -65,25 +71,39 @@ func (t *Status) waitStatus(ctx context.Context, key string) (map[string]string,
 }
 
 func (t *Status) waitStatuses(ctx context.Context, keys ...string) (map[string]string, error) {
+	delay := statusWaitInitialDelay
 	for {
+		for _, key := range keys {
+			cmd := t.client.HGetAll(ctx, key)
+			if err := cmd.Err(); err != nil {
+				return nil, err
+			}
+			val := cmd.Val()
+			if len(val) <= 0 {
+				continue
+			}
+			if value, ok := val["status"]; ok && value != bstatus.StatusSuccess && value != bstatus.StatusFailed {
+				continue
+			}
+			return val, nil
+		}
+
+		jitterRange := max(delay/4, time.Nanosecond)
+		jitter := time.Duration(time.Now().UnixNano() % int64(jitterRange))
+		timer := time.NewTimer(delay + jitter)
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-			for _, key := range keys {
-				cmd := t.client.HGetAll(ctx, key)
-				if err := cmd.Err(); err != nil {
-					return nil, err
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
 				}
-				val := cmd.Val()
-				if len(val) <= 0 {
-					continue
-				}
-				if v, ok := val["status"]; ok && v != bstatus.StatusSuccess && v != bstatus.StatusFailed {
-					continue
-				}
-				return val, nil
 			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+		if delay < statusWaitMaxDelay {
+			delay = min(delay*2, statusWaitMaxDelay)
 		}
 	}
 }

--- a/internal/driver/bredis/stream_consumer.go
+++ b/internal/driver/bredis/stream_consumer.go
@@ -28,6 +28,7 @@ type queueOptions struct {
 	gracefulShutdownTimeout time.Duration
 	captureConfig           *capture.Config
 	wait                    replicationWait
+	metadataCache           *metadataValidationCache
 }
 
 type queueBase struct {

--- a/internal/driver/bredis/ui.go
+++ b/internal/driver/bredis/ui.go
@@ -20,6 +20,8 @@ type UITool struct {
 	prefix string
 }
 
+const queueMessageScanBatch int64 = 100
+
 func NewUITool(client redis.UniversalClient, prefix string) *UITool {
 
 	return &UITool{
@@ -29,33 +31,55 @@ func NewUITool(client redis.UniversalClient, prefix string) *UITool {
 }
 
 func (t *UITool) QueueMessage(ctx context.Context) error {
-	streamKeys, err := t.client.Keys(ctx, "*"+t.prefix+"*:stream*").Result()
-	if err != nil {
-		return fmt.Errorf("list queue streams: %w", err)
-	}
-
 	var total, pending int64
-	for _, streamKey := range streamKeys {
-		keyType, err := t.client.Type(ctx, streamKey).Result()
+	seen := make(map[string]struct{})
+	var cursor uint64
+	for {
+		streamKeys, nextCursor, err := t.client.Scan(ctx, cursor, t.prefix+"*:stream*", queueMessageScanBatch).Result()
 		if err != nil {
-			return fmt.Errorf("read queue key type for %q: %w", streamKey, err)
+			return fmt.Errorf("scan queue streams: %w", err)
 		}
-		if keyType != "stream" {
-			continue
+		cursor = nextCursor
+		keys := make([]string, 0, len(streamKeys))
+		keyTypes := make([]*redis.StatusCmd, 0, len(streamKeys))
+		groupsCommands := make([]*redis.XInfoGroupsCmd, 0, len(streamKeys))
+		lengthCommands := make([]*redis.IntCmd, 0, len(streamKeys))
+		pipe := t.client.Pipeline()
+		for _, streamKey := range streamKeys {
+			if _, exists := seen[streamKey]; exists {
+				continue
+			}
+			seen[streamKey] = struct{}{}
+			keys = append(keys, streamKey)
+			keyTypes = append(keyTypes, pipe.Type(ctx, streamKey))
+			groupsCommands = append(groupsCommands, pipe.XInfoGroups(ctx, streamKey))
+			lengthCommands = append(lengthCommands, pipe.XLen(ctx, streamKey))
 		}
-		groups, err := t.client.XInfoGroups(ctx, streamKey).Result()
-		if err != nil && err != redis.Nil {
-			return fmt.Errorf("read consumer groups for %q: %w", streamKey, err)
+		_, _ = pipe.Exec(ctx)
+		for index, streamKey := range keys {
+			keyType, err := keyTypes[index].Result()
+			if err != nil {
+				return fmt.Errorf("read queue key type for %q: %w", streamKey, err)
+			}
+			if keyType != "stream" {
+				continue
+			}
+			groups, err := groupsCommands[index].Result()
+			if err != nil && err != redis.Nil {
+				return fmt.Errorf("read consumer groups for %q: %w", streamKey, err)
+			}
+			if len(groups) > 0 {
+				pending += groups[0].Pending
+			}
+			length, err := lengthCommands[index].Result()
+			if err != nil {
+				return fmt.Errorf("read stream length for %q: %w", streamKey, err)
+			}
+			total += length
 		}
-		if len(groups) > 0 {
-			pending += groups[0].Pending
+		if cursor == 0 {
+			break
 		}
-
-		length, err := t.client.XLen(ctx, streamKey).Result()
-		if err != nil {
-			return fmt.Errorf("read stream length for %q: %w", streamKey, err)
-		}
-		total += length
 	}
 	if pending < 0 {
 		pending = 0

--- a/internal/driver/bredis/ui.go
+++ b/internal/driver/bredis/ui.go
@@ -98,25 +98,29 @@ func (t *UITool) HostName(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	expiredMembers := make([]any, 0, len(keys)/2)
 	for _, key := range keys {
 		if err := json.NewDecoder(strings.NewReader(key)).Decode(&data); err != nil {
 			continue
 		}
 		if v, ok := data["hostName"]; ok {
 			if cast.ToString(v) == info.Hostname {
-				t.client.ZRem(ctx, hostNameKey, key)
+				expiredMembers = append(expiredMembers, key)
 				data = make(map[string]any, 8)
 				continue
 			}
 		}
 		if v, ok := data["expiredTime"]; ok {
 			if cast.ToInt64(v) < now.Unix() {
-				t.client.ZRem(ctx, hostNameKey, key)
+				expiredMembers = append(expiredMembers, key)
 				data = make(map[string]any, 8)
 				continue
 			}
 		}
 		data = make(map[string]any, 8)
+	}
+	if len(expiredMembers) > 0 {
+		t.client.ZRem(ctx, hostNameKey, expiredMembers...)
 	}
 	memory, err := mem.VirtualMemory()
 	if err != nil {

--- a/internal/routers/redis_info_handler.go
+++ b/internal/routers/redis_info_handler.go
@@ -30,10 +30,8 @@ func NewRedisInfo(client redis.UniversalClient, prefix string, mongo *bmongo.BMo
 	return &RedisInfo{client: client, prefix: prefix, mgo: mongo}
 }
 func (t *RedisInfo) Info(w http.ResponseWriter, r *http.Request) {
-
 	result, cancel := response.Get()
 	defer cancel()
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
@@ -42,30 +40,17 @@ func (t *RedisInfo) Info(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-
-	nctx := r.Context()
+	ctx := r.Context()
 	ticker := time.NewTicker(300 * time.Millisecond)
 	defer ticker.Stop()
-
-	nodeId := r.Header.Get("nodeId")
-	client := tool.ClientFac(t.client, t.prefix, nodeId)
-
-	var (
-		//redis info
-		memory    map[string]any
-		command   []map[string]any
-		clients   map[string]any
-		stats     map[string]any
-		keyspace  []map[string]any
-		eventName = cast.ToString(r.Context().Value(EventName{}))
-	)
-
+	client := tool.ClientFac(t.client, t.prefix, r.Header.Get("nodeId"))
+	eventName := cast.ToString(ctx.Value(EventName{}))
 	for {
 		select {
-		case <-nctx.Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d, err := client.Info(nctx)
+			snapshot, err := client.Snapshot(ctx)
 			if err != nil {
 				result.Code = berror.InternalServerErrorCode
 				result.Msg = err.Error()
@@ -73,64 +58,14 @@ func (t *RedisInfo) Info(w http.ResponseWriter, r *http.Request) {
 				flusher.Flush()
 				return
 			}
-			memory, err = client.Memory(nctx)
-			if err != nil {
-				result.Code = berror.InternalServerErrorCode
-				result.Msg = err.Error()
-				_ = result.EventMsg(w, eventName)
-				flusher.Flush()
-				return
-			}
-
-			command, err = client.CommandStats(nctx)
-			if err != nil {
-				result.Code = berror.InternalServerErrorCode
-				result.Msg = err.Error()
-				_ = result.EventMsg(w, eventName)
-				flusher.Flush()
-				return
-			}
-
-			clients, err = client.Clients(nctx)
-			if err != nil {
-				result.Code = berror.InternalServerErrorCode
-				result.Msg = err.Error()
-				_ = result.EventMsg(w, eventName)
-				flusher.Flush()
-				return
-			}
-
-			stats, err = client.Stats(nctx)
-			if err != nil {
-				result.Code = berror.InternalServerErrorCode
-				result.Msg = err.Error()
-				_ = result.EventMsg(w, eventName)
-				flusher.Flush()
-				return
-			}
-
-			keyspace, err = client.KeySpace(nctx)
-			if err != nil {
-				result.Code = berror.InternalServerErrorCode
-				result.Msg = err.Error()
-				_ = result.EventMsg(w, eventName)
-				flusher.Flush()
-				return
-			}
-
 			result.Data = map[string]any{
-				"info":     d,
-				"commands": command,
-				"clients":  clients,
-				"stats":    stats,
-				"keyspace": keyspace,
-				"memory":   memory,
+				"info": snapshot.Info, "commands": snapshot.Commands,
+				"clients": snapshot.Clients, "stats": snapshot.Stats,
+				"keyspace": snapshot.Keyspace, "memory": snapshot.Memory,
 			}
-
 			_ = result.EventMsg(w, eventName)
 			flusher.Flush()
 			ticker.Reset(10 * time.Second)
-
 		}
 	}
 }


### PR DESCRIPTION
# PR Template

## Description

Optimize the Lua script by using Redis hashes to store state, thereby reducing the number of network `I/O` round-trips.

## Impact

**1. saveHSet.lua** 

- Before modification: Number of fields + 1 `EXPIRE` call
- After modification: 1 `HSET` call + 1 `EXPIRE` call

**2. saveBranches.lua, saveNewTrans.lua**

- Adding N branches: Reduces from N `RPUSH` operations to a single `RPUSH` operation
- Updating N branches: Remains N LSET operations

**3. sequenceQueueEnqueue.lua**

- For the standard queue-entry path involving an existing order state, the number of Redis calls to read the partition state is reduced from two `HGET` operations to a single `HMGET` operation
- Reading the order state is reduced from four `HGET` operations to one `HMGET` operation, with an additional `HGET` call eliminated before the result is returned
- In total, the typical path for an existing state sees a reduction of five `redis.call` operations

**4. sequenceQueueLease.lua**

- The seven `HGET` operations on the normal path are reduced to a single `HMGET`
- The empty-queue path reuses the previously read `depth`, saving another `HGET` operation
- The two `DEL` operations for cleaning up the two keys are reduced to a single `DEL`

**5. sequenceQueueFinalize.lua**

- Identity and status checks: reduced from five `HGET` calls to a single `HMGET` call
- Subsequent branching reuses the `depth` value, further reducing the normal execution path by one `HGET` call
- Cleanup: reduced from two `DEL` calls (one for each key) to a single `DEL` call

**6.Cache confirmed configuration information locally**
- partition ,lease etc.

**7. preload Lua scripts**

**8.reduce Redis connection usage**
- Reduce connection occupancy in the Redis pool using exponential backoff.
